### PR TITLE
fix: forms service expect repo and owner in message body

### DIFF
--- a/src/forms-pipe.js
+++ b/src/forms-pipe.js
@@ -140,10 +140,12 @@ export async function formsPipe(state, request) {
   // sheet and the source location is not null
   const host = getOriginalHost(request.headers);
 
+  // Forms service expect owner and repo in the message body
+  body.owner = owner;
+  body.repo = repo;
+
   const message = {
     url: `https://${ref}--${repo}--${owner}.hlx.live${resourcePath}`,
-    owner,
-    repo,
     body,
     host,
     sourceLocation,

--- a/test/forms-pipe.test.js
+++ b/test/forms-pipe.test.js
@@ -25,8 +25,8 @@ class MockDispatcher {
   // eslint-disable-next-line class-methods-use-this
   async dispatch(message) {
     assert.strictEqual(message.sourceLocation, 'foo-bar');
-    assert.strictEqual(message.owner, 'owner');
-    assert.strictEqual(message.repo, 'repo');
+    assert.strictEqual(message.body.owner, 'owner');
+    assert.strictEqual(message.body.repo, 'repo');
     return {
       requestId: 'fake-requestId',
       messageId: 'fake-message-id',


### PR DESCRIPTION
Forms service expects the `owner` and `repo` to be included as part of the message body. Opted to fix directly in `forms-pipe` rather than in the dispatch method in `SQSMessageDispatcher` as it's not clear to me if other features using SQS pass along `owner` and `repo` to dispatch.

See https://github.com/adobe/helix-forms-service/blob/26e6f880903dc1b5711c3d9266e820bafd1e6efa/src/Utils.js#L139

