### PR TITLE
fix: match globs for mapped pages in maintenance pipeline-service

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,6 +65,11 @@ declare interface PathInfo {
    * original extension as passed via request
    */
   originalExtension: string;
+
+  /**
+   * original path as passed before folder mapping
+   */
+  mappedPath: string;
 }
 
 declare interface S3Loader {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,7 @@ declare interface PathInfo {
   /**
    * original path as passed before folder mapping
    */
-  mappedPath: string;
+  unmappedPath: string;
 }
 
 declare interface S3Loader {

--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -157,7 +157,7 @@ export default function extractMetaData(state, req) {
   // extract global metadata from spreadsheet, and overlay
   // with local metadata from document
   const metaConfig = Object.assign(
-    filterGlobalMetadata(state.metadata, state.info.mappedPath || state.info.path),
+    filterGlobalMetadata(state.metadata, state.info.unmappedPath || state.info.path),
     getLocalMetadata(hast),
   );
 

--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -157,7 +157,7 @@ export default function extractMetaData(state, req) {
   // extract global metadata from spreadsheet, and overlay
   // with local metadata from document
   const metaConfig = Object.assign(
-    filterGlobalMetadata(state.metadata, state.info.path),
+    filterGlobalMetadata(state.metadata, state.info.mappedPath || state.info.path),
     getLocalMetadata(hast),
   );
 

--- a/src/steps/folder-mapping.js
+++ b/src/steps/folder-mapping.js
@@ -48,6 +48,7 @@ export default function folderMapping(state) {
   const mapped = mapPath(folders, path);
   if (mapped) {
     state.info = getPathInfo(mapped);
+    state.info.mappedPath = path;
     if (getExtension(mapped)) {
       // special case: use code-bus
       state.content.sourceBus = 'code';

--- a/src/steps/folder-mapping.js
+++ b/src/steps/folder-mapping.js
@@ -48,7 +48,7 @@ export default function folderMapping(state) {
   const mapped = mapPath(folders, path);
   if (mapped) {
     state.info = getPathInfo(mapped);
-    state.info.mappedPath = path;
+    state.info.unmappedPath = path;
     if (getExtension(mapped)) {
       // special case: use code-bus
       state.content.sourceBus = 'code';

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -37,7 +37,7 @@ export function getPathInfo(path) {
     originalExtension: '',
     originalPath: path,
     originalFilename: segs.pop(),
-    mappedPath: '',
+    unmappedPath: '',
   };
 
   // path         -> web path (no .html, no index)

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -37,6 +37,7 @@ export function getPathInfo(path) {
     originalExtension: '',
     originalPath: path,
     originalFilename: segs.pop(),
+    mappedPath: '',
   };
 
   // path         -> web path (no .html, no index)

--- a/test/fixtures/content/metadata.json
+++ b/test/fixtures/content/metadata.json
@@ -50,6 +50,12 @@
         "Keywords": "Exactomento Folder",
         "og:publisher": "Adobe",
         "Short Title": "E"
+      },
+      {
+        "URL": "/products**",
+        "Keywords": "Exactomento Mapped Folder",
+        "og:publisher": "Adobe",
+        "Short Title": "E"
       }
     ]
   }

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -365,6 +365,20 @@ describe('Rendering', () => {
       });
     });
 
+    it('respect metadata with folder mapping: self and descendents', async () => {
+      let resp = await render(new URL('https://helix-pipeline.com/products'));
+      assert.strictEqual(resp.status, 200);
+      assert.match(resp.body, /<meta name="short-title" content="E">/);
+      assert.match(resp.body, /<meta property="og:publisher" content="Adobe">/);
+      assert.match(resp.body, /<meta name="keywords" content="Exactomento Mapped Folder">/);
+
+      resp = await render(new URL('https://helix-pipeline.com/products/product1'));
+      assert.strictEqual(resp.status, 200);
+      assert.match(resp.body, /<meta name="short-title" content="E">/);
+      assert.match(resp.body, /<meta property="og:publisher" content="Adobe">/);
+      assert.match(resp.body, /<meta name="keywords" content="Exactomento Mapped Folder">/);
+    });
+
     it('uses last modified from helix-config', async () => {
       loader
         .headers('helix-config.json', 'x-amz-meta-x-source-last-modified', 'Wed, 12 Jan 2022 11:33:01 GMT')

--- a/test/utils/path.test.js
+++ b/test/utils/path.test.js
@@ -32,7 +32,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo(''), {
@@ -43,7 +43,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/'), {
@@ -54,7 +54,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express'), {
@@ -65,7 +65,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: 'express',
       originalPath: '/express',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express.html'), {
@@ -76,7 +76,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'express.html',
       originalPath: '/express.html',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express.md'), {
@@ -87,7 +87,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.md',
       originalFilename: 'express.md',
       originalPath: '/express.md',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/'), {
@@ -98,7 +98,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/express/',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index'), {
@@ -109,7 +109,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: 'index',
       originalPath: '/express/index',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index.html'), {
@@ -120,7 +120,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'index.html',
       originalPath: '/express/index.html',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index.md'), {
@@ -131,7 +131,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.md',
       originalFilename: 'index.md',
       originalPath: '/express/index.md',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/query-index.json'), {
@@ -142,7 +142,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.json',
       originalFilename: 'query-index.json',
       originalPath: '/en/query-index.json',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/header.plain.html'), {
@@ -153,7 +153,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'header.plain.html',
       originalPath: '/en/header.plain.html',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/header.plain.json'), {
@@ -164,7 +164,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.json',
       originalFilename: 'header.plain.json',
       originalPath: '/en/header.plain.json',
-      mappedPath: '',
+      unmappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('///en//'), null);

--- a/test/utils/path.test.js
+++ b/test/utils/path.test.js
@@ -32,6 +32,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo(''), {
@@ -42,6 +43,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/'), {
@@ -52,6 +54,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express'), {
@@ -62,6 +65,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: 'express',
       originalPath: '/express',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express.html'), {
@@ -72,6 +76,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'express.html',
       originalPath: '/express.html',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express.md'), {
@@ -82,6 +87,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.md',
       originalFilename: 'express.md',
       originalPath: '/express.md',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/'), {
@@ -92,6 +98,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: '',
       originalPath: '/express/',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index'), {
@@ -102,6 +109,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '',
       originalFilename: 'index',
       originalPath: '/express/index',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index.html'), {
@@ -112,6 +120,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'index.html',
       originalPath: '/express/index.html',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/express/index.md'), {
@@ -122,6 +131,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.md',
       originalFilename: 'index.md',
       originalPath: '/express/index.md',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/query-index.json'), {
@@ -132,6 +142,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.json',
       originalFilename: 'query-index.json',
       originalPath: '/en/query-index.json',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/header.plain.html'), {
@@ -142,6 +153,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.html',
       originalFilename: 'header.plain.html',
       originalPath: '/en/header.plain.html',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('/en/header.plain.json'), {
@@ -152,6 +164,7 @@ describe('Path Utils Test - getPathInfo', () => {
       originalExtension: '.json',
       originalFilename: 'header.plain.json',
       originalPath: '/en/header.plain.json',
+      mappedPath: '',
     });
 
     assert.deepStrictEqual(getPathInfo('///en//'), null);


### PR DESCRIPTION
# Backport for maintenance pipeline-service 

Fixes glob matching for mapped pages

Related Issues
fixes https://github.com/adobe/helix-html-pipeline/issues/69