### PR TITLE
Lazy images

### DIFF
--- a/src/steps/create-pictures.js
+++ b/src/steps/create-pictures.js
@@ -18,7 +18,7 @@ const BREAK_POINTS = [
   { width: '750' },
 ];
 
-export function createOptimizedPicture(src, alt = '', eager = false) {
+export function createOptimizedPicture(src, alt = '') {
   const url = new URL(src, 'https://localhost/');
   const { pathname, hash = '' } = url;
   const props = new URLSearchParams(hash.substring(1));
@@ -53,7 +53,7 @@ export function createOptimizedPicture(src, alt = '', eager = false) {
       });
     }
     return h('img', {
-      loading: eager ? 'eager' : 'lazy',
+      loading: 'lazy',
       alt,
       type: v.type,
       src: srcset,
@@ -77,11 +77,9 @@ function isMediaImage(node) {
 export default async function createPictures({ content }) {
   const { hast } = content;
 
-  let first = true;
   visitParents(hast, isMediaImage, (img, parents) => {
     const { src, alt } = img.properties;
-    const picture = createOptimizedPicture(src, alt, first);
-    first = false;
+    const picture = createOptimizedPicture(src, alt);
 
     // check if parent has style and unwrap if needed
     const parent = parents[parents.length - 1];

--- a/src/steps/set-custom-response-headers.js
+++ b/src/steps/set-custom-response-headers.js
@@ -21,8 +21,8 @@ import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
  */
 export default function setCustomResponseHeaders(state, req, res) {
   Object.entries(state.headers.getModifiers(state.info.path)).forEach(([name, value]) => {
-    // don't use `link` header for non-html pipeline
-    if (name !== 'link' || state.type === 'html') {
+    // only use `link` header for extensionless pipeline
+    if (name !== 'link' || (state.type === 'html' && state.info.selector === '')) {
       res.headers.set(name, cleanupHeaderValue(value));
     }
   });

--- a/test/fixtures/content/image-from-meta.html
+++ b/test/fixtures/content/image-from-meta.html
@@ -26,7 +26,7 @@
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
                 <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                <img loading="eager" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+                <img loading="lazy" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
     </div>

--- a/test/fixtures/content/image-no-alt.html
+++ b/test/fixtures/content/image-no-alt.html
@@ -25,7 +25,7 @@
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
                 <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                <img loading="eager" alt="" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+                <img loading="lazy" alt="" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
     </div>

--- a/test/fixtures/content/image.html
+++ b/test/fixtures/content/image.html
@@ -26,7 +26,7 @@
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
                 <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                <img loading="eager" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+                <img loading="lazy" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
     </div>

--- a/test/fixtures/content/images.html
+++ b/test/fixtures/content/images.html
@@ -6,7 +6,7 @@
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                 <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
                 <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                <img loading="eager" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+                <img loading="lazy" alt="Hero image" type="image/png" src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
         <h2 id="foo">Foo</h2>

--- a/test/fixtures/content/meta-response-headers.plain.html
+++ b/test/fixtures/content/meta-response-headers.plain.html
@@ -1,0 +1,1 @@
+<body><div><h1 id="hello-meta">Hello Meta</h1></div></body>

--- a/test/fixtures/content/page-block-1-col.html
+++ b/test/fixtures/content/page-block-1-col.html
@@ -11,7 +11,7 @@
                             <source type="image/webp" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                             <source type="image/webp" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=webply&#x26;optimize=medium">
                             <source type="image/png" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                            <img loading="eager" alt="" type="image/png" src="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=png&#x26;optimize=medium">
+                            <img loading="lazy" alt="" type="image/png" src="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=png&#x26;optimize=medium">
                         </picture>
                     </p>
                     <h2 id="jesus-ramirez">Jesus Ramirez</h2>

--- a/test/fixtures/content/page-block-1-col.plain.html
+++ b/test/fixtures/content/page-block-1-col.plain.html
@@ -10,7 +10,7 @@
                         <source type="image/webp" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                         <source type="image/webp" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=webply&#x26;optimize=medium">
                         <source type="image/png" srcset="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                        <img loading="eager" alt="" type="image/png" src="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=png&#x26;optimize=medium">
+                        <img loading="lazy" alt="" type="image/png" src="./media_c8248664afb141a601d00412936eff2a20f8d5d4.png?width=750&#x26;format=png&#x26;optimize=medium">
                     </picture>
                 </p>
                 <h2 id="jesus-ramirez">Jesus Ramirez</h2>

--- a/test/fixtures/content/page-block-table-in-table.html
+++ b/test/fixtures/content/page-block-table-in-table.html
@@ -37,7 +37,7 @@
                             <source type="image/webp" srcset="./media_19c0cf25413106c81920d75078ee2ef30a55d52e7.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                             <source type="image/webp" srcset="./media_19c0cf25413106c81920d75078ee2ef30a55d52e7.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
                             <source type="image/jpeg" srcset="./media_19c0cf25413106c81920d75078ee2ef30a55d52e7.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 400px)">
-                            <img loading="eager" alt="" type="image/jpeg" src="./media_19c0cf25413106c81920d75078ee2ef30a55d52e7.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium">
+                            <img loading="lazy" alt="" type="image/jpeg" src="./media_19c0cf25413106c81920d75078ee2ef30a55d52e7.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium">
                         </picture>
                     </p>
                 </div>

--- a/test/fixtures/content/page-block-with-html-table.html
+++ b/test/fixtures/content/page-block-with-html-table.html
@@ -17,7 +17,7 @@
                         <source type="image/webp" srcset="./media_11a313e29672ed8642d1845ca79f7d37c9d9220a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                         <source type="image/webp" srcset="./media_11a313e29672ed8642d1845ca79f7d37c9d9220a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
                         <source type="image/png" srcset="./media_11a313e29672ed8642d1845ca79f7d37c9d9220a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                        <img loading="eager" alt="" type="image/png" src="./media_11a313e29672ed8642d1845ca79f7d37c9d9220a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+                        <img loading="lazy" alt="" type="image/png" src="./media_11a313e29672ed8642d1845ca79f7d37c9d9220a0.png?width=750&#x26;format=png&#x26;optimize=medium">
                     </picture>
                 </div>
                 <div><a href="https://adobesparkpost.app.link/nfQW2NoCVeb">https://adobesparkpost.app.link/nfQW2NoCVeb</a></div>

--- a/test/fixtures/content/stray-p-strong.html
+++ b/test/fixtures/content/stray-p-strong.html
@@ -5,7 +5,7 @@
                 <source type="image/webp" srcset="./media_1ed2c87c973e3e1d2be905503256fd0f241521446.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
                 <source type="image/webp" srcset="./media_1ed2c87c973e3e1d2be905503256fd0f241521446.png?width=750&#x26;format=webply&#x26;optimize=medium">
                 <source type="image/png" srcset="./media_1ed2c87c973e3e1d2be905503256fd0f241521446.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-                <img loading="eager" alt="" type="image/png" src="./media_1ed2c87c973e3e1d2be905503256fd0f241521446.png?width=750&#x26;format=png&#x26;optimize=medium">
+                <img loading="lazy" alt="" type="image/png" src="./media_1ed2c87c973e3e1d2be905503256fd0f241521446.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
         <h1 id="adobe-spark-vs-the-competition">Adobe Spark vs. the Competition</h1>

--- a/test/fixtures/content/styling.plain.html
+++ b/test/fixtures/content/styling.plain.html
@@ -78,7 +78,7 @@ And it continues….
             <source type="image/webp" srcset="./media_10ea15e05c418d85e87762fa60afb9942a4d4ca1e.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
             <source type="image/webp" srcset="./media_10ea15e05c418d85e87762fa60afb9942a4d4ca1e.png?width=750&#x26;format=webply&#x26;optimize=medium">
             <source type="image/png" srcset="./media_10ea15e05c418d85e87762fa60afb9942a4d4ca1e.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 400px)">
-            <img loading="eager" alt="" type="image/png" src="./media_10ea15e05c418d85e87762fa60afb9942a4d4ca1e.png?width=750&#x26;format=png&#x26;optimize=medium">
+            <img loading="lazy" alt="" type="image/png" src="./media_10ea15e05c418d85e87762fa60afb9942a4d4ca1e.png?width=750&#x26;format=png&#x26;optimize=medium">
         </picture>
     </p>
     <p>Empty heading with hr</p>

--- a/test/fixtures/content/unwrap-images.html
+++ b/test/fixtures/content/unwrap-images.html
@@ -29,7 +29,7 @@
             <source type="image/webp" srcset="./media_18957f0bb90a03abb2d30ca76d5aed6b391ca0088.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 400px)">
             <source type="image/webp" srcset="./media_18957f0bb90a03abb2d30ca76d5aed6b391ca0088.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
             <source type="image/jpeg" srcset="./media_18957f0bb90a03abb2d30ca76d5aed6b391ca0088.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 400px)">
-            <img loading="eager" alt="" type="image/jpeg" src="./media_18957f0bb90a03abb2d30ca76d5aed6b391ca0088.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="2000" height="876">
+            <img loading="lazy" alt="" type="image/jpeg" src="./media_18957f0bb90a03abb2d30ca76d5aed6b391ca0088.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="2000" height="876">
         </picture>
     </div>
     <div>

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -462,5 +462,21 @@ describe('Rendering', () => {
         'x-surrogate-key': 'zh7-SbNEyY3CnWoh foo-id_metadata super-test--helix-pages--adobe_head',
       });
     });
+
+    it('uses response headers from metadata.json (ignores link on .plain.html)', async () => {
+      loader.status('config-all.json', 404);
+      loader.rewrite('metadata.json', 'metadata-headers.json');
+
+      const { headers } = await testRenderPlain('meta-response-headers');
+      assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
+        'content-type': 'text/html; charset=utf-8',
+        'content-security-policy': "default-src 'self'",
+        'content-security-policy-report-only': 'true',
+        'access-control-allow-methods': 'GET, POST, OPTIONS',
+        'access-control-allow-origin': '*',
+        'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
+        'x-surrogate-key': 'zh7-SbNEyY3CnWoh',
+      });
+    });
   });
 });


### PR DESCRIPTION
### Changes

- always use `loading="lazy"` on all img tags

### Fixes
- suppress `link` response headers on .plain.html (and non html)