### PR TITLE
fix: return 200 with no default sheet, 404 with unmatched sheet filter

### DIFF
--- a/src/utils/json-filter.js
+++ b/src/utils/json-filter.js
@@ -110,7 +110,7 @@ export default function jsonFilter(state, data, query) {
       sheets[name] = filter(json[name]);
       sheetNames.push(name);
     });
-  if (sheetNames.length === 0) {
+  if (sheetNames.length === 0 && requestedSheets.length > 0) {
     const msg = `filtered result does not contain selected sheet(s): ${requestedSheets.join(',')}`;
     log.info(msg);
     return new PipelineResponse('', {

--- a/test/utils/json-filter.test.js
+++ b/test/utils/json-filter.test.js
@@ -38,6 +38,7 @@ describe('JSON Filter test', () => {
   let TEST_SINGLE_SHEET;
   let TEST_MULTI_SHEET;
   let TEST_MULTI_SHEET_DEFAULT;
+  let TEST_NO_DEFAULT_SHEET;
 
   before(async () => {
     TEST_DATA = JSON.parse(await readFile(path.resolve(__testdir, 'fixtures', 'json', 'test-data.json'), 'utf-8'));
@@ -59,6 +60,8 @@ describe('JSON Filter test', () => {
       sheet1: TEST_SINGLE_SHEET,
       default: TEST_SINGLE_SHEET,
     };
+
+    TEST_NO_DEFAULT_SHEET = { ':names': [] };
   });
 
   it('returns same response for single sheet with no query', async () => {
@@ -85,6 +88,19 @@ describe('JSON Filter test', () => {
       total: TEST_DATA.length,
       data: TEST_DATA,
       ':type': 'sheet',
+    });
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'content-type': 'application/json',
+    });
+  });
+
+  it('returns 200 with no default', async () => {
+    const resp = jsonFilter(DEFAULT_CONTEXT, JSON.stringify(TEST_NO_DEFAULT_SHEET), {});
+    assert.strictEqual(resp.status, 200);
+    assert.deepStrictEqual(await resp.json(), {
+      ':names': [],
+      ':type': 'multi-sheet',
+      ':version': 3,
     });
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
@@ -237,6 +253,15 @@ describe('JSON Filter test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
     });
+  });
+
+  it('filter by sheet - no default/sheets', async () => {
+    const resp = jsonFilter(
+      DEFAULT_CONTEXT,
+      JSON.stringify(TEST_NO_DEFAULT_SHEET),
+      { sheet: 'sheet1' },
+    );
+    assert.strictEqual(resp.status, 404);
   });
 
   it('filter by unknown sheet returns 404', async () => {


### PR DESCRIPTION
# Support GET operations on workbooks with no default sheet in content-bus

In [697](https://github.com/adobe/helix-admin/pull/698) support was added to `preview` workbooks that only contain a `incoming` sheet (no `helix-default`). The result of this is a json file in the content bus with the following data.

```json
{":version":3,":type":"multi-sheet",":names":[]}
```

Currently the pipeline will return a 404 when a `GET` request made on this resource because the `names` property is empty. This PR changes this behaviour to instead return a 200 (including the data). 

A 404 will now only be returned if a sheet filter is explicitly provided in the query params.

The justification for this change is that customers will have a confusing/bad experience when they preview a workbook (with no default sheet) in sidekick and the result is a 404. 

More details in https://github.com/adobe/helix-admin/issues/697

