### PR TITLE
fix(html): do not skip custom headers for 3xx responses

### DIFF
--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -80,6 +80,9 @@ export async function htmlPipe(state, req) {
       // if content loading produced an error, we're done.
       log.error(`error running pipeline: ${res.status} ${res.error}`);
       res.headers.set('x-error', cleanupHeaderValue(res.error));
+      if (res.status < 500) {
+        await setCustomResponseHeaders(state, req, res);
+      }
       return res;
     }
 

--- a/src/json-pipe.js
+++ b/src/json-pipe.js
@@ -89,8 +89,10 @@ export async function jsonPipe(state, req) {
 
   // if still not found, return status
   if (dataResponse.status !== 200) {
-    await fetchMetadata(state, req, dataResponse);
-    await setCustomResponseHeaders(state, req, dataResponse);
+    if (dataResponse.status < 500) {
+      await fetchMetadata(state, req, dataResponse);
+      await setCustomResponseHeaders(state, req, dataResponse);
+    }
     return dataResponse;
   }
   const data = dataResponse.body;

--- a/src/json-pipe.js
+++ b/src/json-pipe.js
@@ -89,6 +89,8 @@ export async function jsonPipe(state, req) {
 
   // if still not found, return status
   if (dataResponse.status !== 200) {
+    await fetchMetadata(state, req, dataResponse);
+    await setCustomResponseHeaders(state, req, dataResponse);
     return dataResponse;
   }
   const data = dataResponse.body;

--- a/test/json-pipe.test.js
+++ b/test/json-pipe.test.js
@@ -172,6 +172,32 @@ describe('JSON Pipe Test', () => {
     });
   });
 
+  it('applies custom header also to errors', async () => {
+    const state = createDefaultState();
+    state.s3Loader.reply(
+      'helix-content-bus',
+      'foobar/preview/metadata.json',
+      new PipelineResponse(JSON.stringify({
+        data: [
+          { 'url': '/**', 'access-control-allow-origin': '*' },
+          { 'url': '/**', 'content-security-policy': "default-src 'self'" },
+        ],
+      }), {
+        headers: {
+          'last-modified': 'Wed, 11 Oct 2009 17:50:00 GMT',
+        },
+      }),
+    )
+      .reply('helix-content-bus', 'foobar/preview/en/index.json', null);
+    const resp = await jsonPipe(state, new PipelineRequest('https://not-found.json'));
+    assert.strictEqual(resp.status, 404);
+    const headers = Object.fromEntries(resp.headers.entries());
+    assert.deepStrictEqual(headers, {
+      'access-control-allow-origin': '*',
+      'content-security-policy': 'default-src \'self\'',
+    });
+  });
+
   it('ignores newer last modified from metadata.json even if newer', async () => {
     const state = createDefaultState();
     state.s3Loader.reply(

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -42,7 +42,7 @@ describe('Rendering', () => {
       path: selector ? `${url.pathname}${selector}.html` : url.pathname,
       contentBusId: 'foo-id',
       timer: {
-        update: () => {},
+        update: () => { },
       },
     });
 
@@ -300,7 +300,18 @@ describe('Rendering', () => {
     });
 
     it('renders 404 if content not found', async () => {
-      await testRender('not-found', 'html');
+      loader.rewrite('metadata.json', 'metadata-headers.json');
+      const { headers } = await testRender('not-found', 'html');
+      assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
+        'access-control-allow-methods': 'GET, POST, OPTIONS',
+        'access-control-allow-origin': '*',
+        'content-security-policy': "default-src 'self'",
+        'content-security-policy-report-only': 'true',
+        'content-type': 'text/html; charset=utf-8',
+        'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
+        link: '/more-styles.css',
+        'x-error': 'failed to load /not-found.md from content-bus: 404',
+      });
     });
 
     it('renders 404.html if content not found', async () => {
@@ -311,8 +322,8 @@ describe('Rendering', () => {
       assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
         'content-type': 'text/html; charset=utf-8',
         'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
-        'x-surrogate-key': 'super-test--helix-pages--adobe_404',
         'x-error': 'failed to load /not-found-with-handler.md from content-bus: 404',
+        'x-surrogate-key': 'super-test--helix-pages--adobe_404',
       });
       assert.strictEqual(body.trim(), '<html><body>There might be dragons.</body></html>');
     });


### PR DESCRIPTION
fixes #153

- same as #154 for the 1.x branch
- also add headers to the json-pipe (to be done in the main branch)

