### PR TITLE
feat: respect x-forwarded-proto in auth

### DIFF
--- a/test/html-pipe.test.js
+++ b/test/html-pipe.test.js
@@ -94,6 +94,7 @@ describe('HTML Pipe Test', () => {
       // this is our own login redirect, i.e. the current document
       requestPath: '/en',
       requestHost: 'www.hlx.live',
+      requestProto: 'https',
     }).encode();
 
     const req = new PipelineRequest('https://localhost/.auth', {


### PR DESCRIPTION
needed for local development of access controlled projects.
otherwise auth redirect would go to `https://localhost` which is currently not supported.