### PR TITLE
feat: also support x-fwd-scheme

### DIFF
--- a/src/utils/auth-cookie.js
+++ b/src/utils/auth-cookie.js
@@ -11,21 +11,21 @@
  */
 import { parse, serialize } from 'cookie';
 
-export function clearAuthCookie() {
+export function clearAuthCookie(secure) {
   return serialize('hlx-auth-token', '', {
     path: '/',
     httpOnly: true,
-    secure: true,
+    secure,
     expires: new Date(0),
     sameSite: 'lax',
   });
 }
 
-export function setAuthCookie(idToken) {
+export function setAuthCookie(idToken, secure) {
   return serialize('hlx-auth-token', idToken, {
     path: '/',
     httpOnly: true,
-    secure: true,
+    secure,
     sameSite: 'lax',
   });
 }

--- a/test/utils/auth-cookie.test.js
+++ b/test/utils/auth-cookie.test.js
@@ -16,12 +16,23 @@ import { clearAuthCookie, getAuthCookie, setAuthCookie } from '../../src/utils/a
 
 describe('Auth Cookie Test', () => {
   it('clears the auth cookie', () => {
-    assert.strictEqual(clearAuthCookie(), 'hlx-auth-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax');
+    assert.strictEqual(clearAuthCookie(), 'hlx-auth-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax');
+  });
+
+  it('clears the auth cookie (secure)', () => {
+    assert.strictEqual(clearAuthCookie(true), 'hlx-auth-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax');
   });
 
   it('sets the auth cookie', () => {
     assert.strictEqual(
       setAuthCookie('1234'),
+      'hlx-auth-token=1234; Path=/; HttpOnly; SameSite=Lax',
+    );
+  });
+
+  it('sets the auth cookie (secure)', () => {
+    assert.strictEqual(
+      setAuthCookie('1234', true),
       'hlx-auth-token=1234; Path=/; HttpOnly; Secure; SameSite=Lax',
     );
   });

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -398,6 +398,30 @@ describe('AuthInfo tests', () => {
     });
   });
 
+  it('redirects to the login page (xfh, scheme)', async () => {
+    const authInfo = AuthInfo
+      .Default()
+      .withIdp(idpFakeTestIDP);
+
+    const state = new PipelineState({});
+    const req = new PipelineRequest('https://localhost', {
+      headers: {
+        'x-forwarded-host': 'localhost',
+        'x-forwarded-scheme': 'http',
+        'x-forwarded-proto': 'ftp',
+      },
+    });
+    const res = new PipelineResponse();
+    await authInfo.redirectToLogin(state, req, res);
+    assert.strictEqual(res.status, 302);
+    const reqState = new URL(res.headers.get('location')).searchParams.get('state');
+    assert.deepStrictEqual(decodeJwt(reqState), {
+      requestHost: 'localhost',
+      requestProto: 'http',
+      requestPath: '/',
+    });
+  });
+
   it('redirects to the login page (xfh - multi)', async () => {
     const authInfo = AuthInfo
       .Default()


### PR DESCRIPTION
fastly overrides the `x-forwarded-proto` with a fixed `https` value. so we also add support for `x-forwarded-scheme` header to support localhost development