### PR TITLE
fix: use info for response status < 500

### DIFF
--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -78,7 +78,8 @@ export async function htmlPipe(state, req) {
 
     if (res.error) {
       // if content loading produced an error, we're done.
-      log.error(`error running pipeline: ${res.status} ${res.error}`);
+      const level = res.status >= 500 ? 'error' : 'info';
+      log[level](`pipeline status: ${res.status} ${res.error}`);
       res.headers.set('x-error', cleanupHeaderValue(res.error));
       if (res.status < 500) {
         await setCustomResponseHeaders(state, req, res);

--- a/test/html-pipe.test.js
+++ b/test/html-pipe.test.js
@@ -50,6 +50,25 @@ describe('Index Tests', () => {
     assert.strictEqual(resp.headers.get('x-error'), 'invalid url: https://${jndi:dns://3.238.15.214/ORTbVlfjTl}/');
   });
 
+  it('responds with 500 for content-bus errors', async () => {
+    const resp = await htmlPipe(
+      new PipelineState({
+        log: console,
+        s3Loader: new FileS3Loader().status('index.md', 500),
+        owner: 'adobe',
+        repo: 'helix-pages',
+        ref: 'super-test',
+        partition: 'live',
+        path: '/',
+        contentBusId: 'foo-id',
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 502);
+    // eslint-disable-next-line no-template-curly-in-string
+    assert.strictEqual(resp.headers.get('x-error'), 'failed to load /index.md from content-bus: 500');
+  });
+
   it('responds with 500 for pipeline errors', async () => {
     /** @type htmlPipe */
     const { htmlPipe: mockPipe } = await esmock('../src/html-pipe.js', {


### PR DESCRIPTION
another occurrence of `log.error` that I missed 🙄 