### PR TITLE
fix: do not render empty canonical meta tag

### DIFF
--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -55,7 +55,9 @@ export default async function render(state, req, res) {
     $head.children.push(h('title', meta.title));
   }
 
-  appendElement($head, createElement('link', 'rel', 'canonical', 'href', meta.canonical));
+  if (meta.canonical) {
+    appendElement($head, createElement('link', 'rel', 'canonical', 'href', meta.canonical));
+  }
 
   for (const [name, value] of Object.entries(meta.page)) {
     const attr = name.includes(':') && !name.startsWith('twitter:') ? 'property' : 'name';

--- a/test/fixtures/content/page-metadata-no-fallback.html
+++ b/test/fixtures/content/page-metadata-no-fallback.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title></title>
-    <link rel="canonical" href="">
     <meta name="description" content="">
     <meta property="og:title" content="">
     <meta property="og:description" content="">


### PR DESCRIPTION
see https://github.com/adobe/helix-pipeline-service/issues/696
