### PR TITLE
Fix: cache length for speed

### DIFF
--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -24,7 +24,7 @@ function appendElement($parent, $el) {
 function createElement(name, ...attrs) {
   // check for empty values
   const properties = {};
-  for (let i = 0; i < attrs.length; i += 2) {
+  for (let i = 0, length = attrs.length; i < length; i += 2) {
     const value = attrs[i + 1];
     if (value === undefined) {
       return null;


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

No related issue, just saw we could cache the length of the array to speed up the loop.