### PR TITLE
feat: add pipeline for sitemap.xml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export * from './html-pipe.js';
 export * from './json-pipe.js';
 export * from './options-pipe.js';
 export * from './forms-pipe.js';
+export * from './sitemap-pipe.js';
 export * from './PipelineContent.js';
 export * from './PipelineRequest.js';
 export * from './PipelineResponse.js';

--- a/src/sitemap-pipe.js
+++ b/src/sitemap-pipe.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
+import { authenticate, requireProject } from './steps/authenticate.js';
+import fetchConfig from './steps/fetch-config.js';
+import fetchContent from './steps/fetch-content.js';
+import fetchConfigAll from './steps/fetch-config-all.js';
+import renderCode from './steps/render-code.js';
+import setXSurrogateKeyHeader from './steps/set-x-surrogate-key-header.js';
+import setCustomResponseHeaders from './steps/set-custom-response-headers.js';
+import { PipelineStatusError } from './PipelineStatusError.js';
+import { PipelineResponse } from './PipelineResponse.js';
+
+/**
+ * Serves or renders the sitemap xml. The sitemap is always served from the preview content-bus
+ * partition.
+ *
+ * todo: currently only serves an existing sitemap.xml from the contentbus.
+ *       generate sitemap on the fly based on the sitemap.json
+ *
+ * @param {PipelineState} state
+ * @param {PipelineRequest} req
+ * @returns {PipelineResponse}
+ */
+export async function sitemapPipe(state, req) {
+  const { log } = state;
+  state.type = 'sitemap';
+  // force loading from preview
+  state.partition = 'preview';
+
+  if (state.info?.path !== '/sitemap.xml') {
+    // this should not happen as it would mean that the caller used the wrong route. so we respond
+    // with a 500 to indicate that something is wrong.
+    return new PipelineResponse('', {
+      status: 500,
+      headers: {
+        'x-error': 'invalid route',
+      },
+    });
+  }
+
+  /** @type PipelineResponse */
+  const res = new PipelineResponse('', {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+
+  // check if .auth request
+
+  try { // fetch config first, since we need to compute the content-bus-id from the fstab ...
+    state.timer?.update('config-fetch');
+    await fetchConfig(state, req, res);
+    if (!state.contentBusId) {
+      res.status = 400;
+      res.headers.set('x-error', 'contentBusId missing');
+      return res;
+    }
+
+    // fetch sitemap.xml
+
+    state.timer?.update('content-fetch');
+    await Promise.all([
+      fetchConfigAll(state, req, res),
+      fetchContent(state, req, res),
+    ]);
+
+    await requireProject(state, req, res);
+    if (res.error !== 401) {
+      await authenticate(state, req, res);
+    }
+
+    if (res.error) {
+      // if content loading produced an error, we're done.
+      const level = res.status >= 500 ? 'error' : 'info';
+      log[level](`pipeline status: ${res.status} ${res.error}`);
+      res.headers.set('x-error', cleanupHeaderValue(res.error));
+      if (res.status < 500) {
+        await setCustomResponseHeaders(state, req, res);
+      }
+      return res;
+    }
+
+    state.timer?.update('serialize');
+    await renderCode(state, req, res);
+    await setCustomResponseHeaders(state, req, res);
+    await setXSurrogateKeyHeader(state, req, res);
+  } catch (e) {
+    res.error = e.message;
+    if (e instanceof PipelineStatusError) {
+      res.status = e.code;
+    } else {
+      res.status = 500;
+    }
+
+    const level = res.status >= 500 ? 'error' : 'info';
+    log[level](`pipeline status: ${res.status} ${res.error}`, e);
+    res.headers.set('x-error', cleanupHeaderValue(res.error));
+  }
+
+  return res;
+}

--- a/test/fixtures/content/sitemap.xml
+++ b/test/fixtures/content/sitemap.xml
@@ -1,0 +1,8 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    <url>
+        <loc>https://www.aem.live/</loc>
+    </url>
+    <url>
+        <loc>https://www.aem.live/developer</loc>
+    </url>
+</urlset>

--- a/test/sitemap-pipe.test.js
+++ b/test/sitemap-pipe.test.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import esmock from 'esmock';
+import { FileS3Loader } from './FileS3Loader.js';
+import {
+  sitemapPipe, PipelineRequest, PipelineResponse, PipelineState,
+} from '../src/index.js';
+import { StaticS3Loader } from './StaticS3Loader.js';
+
+describe('Sitemap Pipe Test', () => {
+  it('responds with 500 for non sitemap', async () => {
+    const resp = await sitemapPipe(
+      new PipelineState({ path: '/foo.html' }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 500);
+    assert.strictEqual(resp.headers.get('x-error'), 'invalid route');
+  });
+
+  it('responds with 500 for content-bus errors', async () => {
+    const resp = await sitemapPipe(
+      new PipelineState({
+        log: console,
+        s3Loader: new FileS3Loader().status('sitemap.xml', 500),
+        owner: 'adobe',
+        repo: 'helix-pages',
+        ref: 'super-test',
+        partition: 'live',
+        path: '/sitemap.xml',
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 502);
+    assert.strictEqual(resp.headers.get('x-error'), 'failed to load /sitemap.xml from content-bus: 500');
+  });
+
+  it('responds with 404 for sitemap not found', async () => {
+    const resp = await sitemapPipe(
+      new PipelineState({
+        log: console,
+        s3Loader: new FileS3Loader().status('sitemap.xml', 404),
+        owner: 'adobe',
+        repo: 'helix-pages',
+        ref: 'super-test',
+        partition: 'live',
+        path: '/sitemap.xml',
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 404);
+    assert.strictEqual(resp.headers.get('x-error'), 'failed to load /sitemap.xml from content-bus: 404');
+  });
+
+  it('responds with 500 for pipeline errors', async () => {
+    /** @type sitemapPipe */
+    const { sitemapPipe: mockPipe } = await esmock('../src/sitemap-pipe.js', {
+      '../src/steps/fetch-config.js': () => {
+        throw Error('kaputt');
+      },
+    });
+
+    const resp = await mockPipe(
+      new PipelineState({ s3Loader: new FileS3Loader(), path: '/sitemap.xml' }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 500);
+    assert.strictEqual(resp.headers.get('x-error'), 'kaputt');
+  });
+
+  it('responds with 400 for missing contentBusId', async () => {
+    const resp = await sitemapPipe(
+      new PipelineState({
+        path: '/sitemap.xml',
+        owner: 'owner',
+        repo: 'repo',
+        ref: 'ref',
+        s3Loader: new StaticS3Loader()
+          .reply(
+            'helix-code-bus',
+            'owner/repo/ref/helix-config.json',
+            new PipelineResponse('{}'),
+          ),
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 400);
+    assert.strictEqual(resp.headers.get('x-error'), 'contentBusId missing');
+  });
+
+  it('responds with 500 for missing helix-config', async () => {
+    const resp = await sitemapPipe(
+      new PipelineState({
+        path: '/sitemap.xml',
+        owner: 'owner',
+        repo: 'repo',
+        ref: 'ref',
+        s3Loader: new FileS3Loader().status('helix-config.json', 404),
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 404);
+    assert.strictEqual(resp.headers.get('x-error'), 'unable to load /helix-config.json: 404');
+  });
+
+  it('serves sitemap.xml', async () => {
+    const s3Loader = new FileS3Loader();
+    const state = new PipelineState({
+      log: console,
+      s3Loader,
+      owner: 'adobe',
+      repo: 'helix-pages',
+      ref: 'super-test',
+      partition: 'live',
+      path: '/sitemap.xml',
+      timer: {
+        update: () => { },
+      },
+    });
+    const resp = await sitemapPipe(
+      state,
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 200);
+    assert.ok(resp.body.startsWith('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9'));
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'access-control-allow-origin': '*',
+      'content-type': 'application/xml; charset=utf-8',
+      'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
+      'x-surrogate-key': 'rCCgYLwPe4ckYgJ7 lkDPpF5moMrrCXQM foo-id_metadata super-test--helix-pages--adobe_head',
+    });
+  });
+});


### PR DESCRIPTION
fixes #472 partially

this is the first step of implement the dynamic sitemap rendering, by just serving it from content-bus if avaialble.

still todo in a subsequent PR: check if sitemap.json can be loaded and generate the sitemap dynamically.