### PR TITLE
feat: rewrite metadata urls

### DIFF
--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -14,7 +14,7 @@ import { toString } from 'hast-util-to-string';
 import { remove } from 'unist-util-remove';
 import { visit, EXIT, CONTINUE } from 'unist-util-visit';
 import {
-  getAbsoluteUrl, makeCanonicalHtmlUrl, optimizeImageURL, resolveUrl,
+  getAbsoluteUrl, makeCanonicalHtmlUrl, optimizeImageURL, resolveUrl, makeAbsoluteURLForMeta,
 } from './utils.js';
 import { toMetaName } from '../utils/modifiers.js';
 import { childNodes } from '../utils/hast-utils.js';
@@ -293,10 +293,16 @@ export default function extractMetaData(state, req) {
     }
   }
 
-  // remove undefined metadata
   for (const name of Object.keys(metadata)) {
     if (metadata[name] === undefined) {
+      // remove undefined metadata
       delete metadata[name];
+    } else if (Array.isArray(metadata[name])) {
+      // make absolute URLs for arrays
+      metadata[name] = metadata[name].map((value) => makeAbsoluteURLForMeta(state, value));
+    } else {
+      // make absolute URLs for strings
+      metadata[name] = makeAbsoluteURLForMeta(state, metadata[name]);
     }
   }
 

--- a/src/steps/utils.js
+++ b/src/steps/utils.js
@@ -236,7 +236,7 @@ export function toArray(v) {
 export function makeAbsoluteURLForMeta(state, meta) {
   if (meta && meta.startsWith('http')) {
     const rewrite = [];
-    const split = meta.split(', ');
+    const split = meta.split(/\s*,\s*/).map((v) => v.trim());
 
     const previewSuffix = state.previewHost?.replace(/^.*?--/, '--');
     const liveSuffix = state.liveHost?.replace(/^.*?--/, '--');

--- a/test/fixtures/content/page-metadata-block-urls.html
+++ b/test/fixtures/content/page-metadata-block-urls.html
@@ -1,0 +1,30 @@
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/page-metadata-block-urls">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/page-metadata-block-urls">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <meta name="page-url-branch" content="https://www.adobe.com/page.html">
+    <meta name="live-url-branch" content="https://www.adobe.com/live.html">
+    <meta name="page-url-main" content="https://www.adobe.com/page.html">
+    <meta name="live-url-main" content="https://www.adobe.com/live.html">
+    <meta name="prod-url" content="https://www.adobe.com/prod-page.html">
+    <meta name="hlx-page-url" content="https://www.adobe.com/express/">
+    <meta name="hlx-page-urls-1" content="https://www.adobe.com/express/page1, https://www.adobe.com/express/page2">
+    <meta name="hlx-page-urls-2" content="https://www.adobe.com/express/page1, https://www.adobe.com/express/page2">
+    <meta name="hlx-live-url" content="https://www.adobe.com/express/">
+    <meta name="branch-hlx-live-url" content="https://www.adobe.com/express/">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+  </head>

--- a/test/fixtures/content/page-metadata-block-urls.html
+++ b/test/fixtures/content/page-metadata-block-urls.html
@@ -20,7 +20,8 @@
     <meta name="prod-url" content="https://www.adobe.com/prod-page.html">
     <meta name="hlx-page-url" content="https://www.adobe.com/express/">
     <meta name="hlx-page-urls-1" content="https://www.adobe.com/express/page1, https://www.adobe.com/express/page2">
-    <meta name="hlx-page-urls-2" content="https://www.adobe.com/express/page1, https://www.adobe.com/express/page2">
+    <meta name="hlx-page-urls-2" content="https://www.adobe.com/express/page3, https://www.adobe.com/express/page4">
+    <meta name="hlx-page-urls-3" content="https://www.adobe.com/express/page5, https://www.adobe.com/express/page6">
     <meta name="hlx-live-url" content="https://www.adobe.com/express/">
     <meta name="branch-hlx-live-url" content="https://www.adobe.com/express/">
     <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">

--- a/test/fixtures/content/page-metadata-block-urls.md
+++ b/test/fixtures/content/page-metadata-block-urls.md
@@ -17,9 +17,15 @@
   <tr>
     <td>hlx.page urls 2</td>
     <td>
+      <p><a href="https://main--helix-pages--adobe.hlx.page/express/page3">https://main--helix-pages--adobe.hlx.page/express/page3</a>&nbsp;</p>
+      <p><a href="https://main--helix-pages--adobe.hlx.page/express/page4">https://main--helix-pages--adobe.hlx.page/express/page4</a>&nbsp;</p></td>
+  </tr>
+  <tr>
+    <td>hlx.page urls 3</td>
+    <td>
       <ul>
-        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page1">https://main--helix-pages--adobe.hlx.page/express/page1</a></li>
-        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page2">https://main--helix-pages--adobe.hlx.page/express/page2</a></li>
+        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page5">https://main--helix-pages--adobe.hlx.page/express/page5</a></li>
+        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page6">https://main--helix-pages--adobe.hlx.page/express/page6</a></li>
       </ul>
     </td>
   </tr>

--- a/test/fixtures/content/page-metadata-block-urls.md
+++ b/test/fixtures/content/page-metadata-block-urls.md
@@ -1,0 +1,34 @@
+# Metadata URLs rewrite Test
+
+<table>
+  <tr>
+    <td>Metadata</td>
+  </tr>
+  <tr>
+    <td>hlx.page url</td>
+    <td><a href="https://main--helix-pages--adobe.hlx.page/express/">https://main--helix-pages--adobe.hlx.page/express/</a></td>
+  </tr>
+  <tr>
+    <td>hlx.page urls 1</td>
+    <td>
+      <p><a href="https://main--helix-pages--adobe.hlx.page/express/page1">https://main--helix-pages--adobe.hlx.page/express/page1</a></p>
+      <p><a href="https://main--helix-pages--adobe.hlx.page/express/page2">https://main--helix-pages--adobe.hlx.page/express/page2</a></p></td>
+  </tr>
+  <tr>
+    <td>hlx.page urls 2</td>
+    <td>
+      <ul>
+        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page1">https://main--helix-pages--adobe.hlx.page/express/page1</a></li>
+        <li><a href="https://main--helix-pages--adobe.hlx.page/express/page2">https://main--helix-pages--adobe.hlx.page/express/page2</a></li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>hlx.live url</td>
+    <td><a href="https://main--helix-pages--adobe.hlx.live/express/">https://main--helix-pages--adobe.hlx.page/express/</a></td>
+  </tr>
+  <tr>
+    <td>branch hlx.live url</td>
+    <td><a href="https://another-ref--helix-pages--adobe.hlx.live/express/">https://another-ref--helix-pages--adobe.hlx.page/express/</a></td>
+  </tr>
+</table>

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -398,6 +398,35 @@ describe('Rendering', () => {
       config = DEFAULT_CONFIG_EMPTY;
       await testRender('page-metadata-twitter-fallback', 'head');
     });
+
+    it('renders meta with URLs - rewrites urls', async () => {
+      config = structuredClone(DEFAULT_CONFIG);
+      config.cdn.preview = {
+        host: '$ref--$repo--$owner.hlx.page',
+      };
+      config.cdn.live = {
+        host: '$ref--$site--$org.hlx.live',
+      };
+
+      config.metadata.live.data['/**'] = config.metadata.live.data['/**'].concat([{
+        key: 'page-url-branch',
+        value: 'https://super-test--helix-pages--adobe.hlx.page/page.html',
+      }, {
+        key: 'live-url-branch',
+        value: 'https://super-test--helix-pages--adobe.hlx.live/live.html',
+      }, {
+        key: 'page-url-main',
+        value: 'https://main--helix-pages--adobe.hlx.page/page.html',
+      }, {
+        key: 'live-url-main',
+        value: 'https://main--helix-pages--adobe.hlx.live/live.html',
+      }, {
+        key: 'prod-url',
+        value: 'https://www.adobe.com/prod-page.html',
+      }]);
+
+      await testRender('page-metadata-block-urls', 'head');
+    });
   });
 
   describe('Miscellaneous', () => {


### PR DESCRIPTION
Fix #501 

Will need several eyes on this one because it changes how URLs in metadata are treated. With the change, you should not have a url in the metadata in the form of `https://${ref}--${repo}--${owner}.hlx.page|live` in production. While this is a must-have in production, this will also be the case in preview and live.
Any client-side code handling those meta should still be working because they anyway have to deal already with authors pasting any of the 3 host urls in the content. But at least, hlx.page and hlx.live urls will not appear in production.
