### PR TITLE
fix: put <loc> on a single line

### DIFF
--- a/src/sitemap-pipe.js
+++ b/src/sitemap-pipe.js
@@ -45,9 +45,7 @@ async function generateSitemap(state, partition) {
     ? (previewHost || `${ref}--${repo}--${owner}.hlx.page`)
     : (prodCDN || liveHost || `${ref}--${repo}--${owner}.hlx.live`);
   const loc = ({ path, lastModified }) => `  <url>
-    <loc>
-      https://${host}${escape(path)}
-    </loc>
+    <loc>https://${host}${escape(path)}</loc>
     <lastmod>${new Date(lastModified * 1000).toISOString().substring(0, 10)}</lastmod>
   </url>`;
   const xml = [

--- a/test/sitemap-pipe.test.js
+++ b/test/sitemap-pipe.test.js
@@ -150,15 +150,11 @@ describe('Sitemap Pipe Test', () => {
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>
-      https://ref--repo--owner.my.page/
-    </loc>
+    <loc>https://ref--repo--owner.my.page/</loc>
     <lastmod>2023-11-30</lastmod>
   </url>
   <url>
-    <loc>
-      https://ref--repo--owner.my.page/test
-    </loc>
+    <loc>https://ref--repo--owner.my.page/test</loc>
     <lastmod>2023-12-21</lastmod>
   </url>
 </urlset>`);
@@ -188,15 +184,11 @@ describe('Sitemap Pipe Test', () => {
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>
-      https://ref--repo--owner.hlx.page/
-    </loc>
+    <loc>https://ref--repo--owner.hlx.page/</loc>
     <lastmod>2023-11-30</lastmod>
   </url>
   <url>
-    <loc>
-      https://ref--repo--owner.hlx.page/test
-    </loc>
+    <loc>https://ref--repo--owner.hlx.page/test</loc>
     <lastmod>2023-12-21</lastmod>
   </url>
 </urlset>`);
@@ -225,15 +217,11 @@ describe('Sitemap Pipe Test', () => {
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>
-      https://www.adobe.com/
-    </loc>
+    <loc>https://www.adobe.com/</loc>
     <lastmod>2023-11-30</lastmod>
   </url>
   <url>
-    <loc>
-      https://www.adobe.com/test
-    </loc>
+    <loc>https://www.adobe.com/test</loc>
     <lastmod>2023-12-21</lastmod>
   </url>
 </urlset>`);
@@ -263,15 +251,11 @@ describe('Sitemap Pipe Test', () => {
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>
-      https://ref--repo--owner.hlx.live/
-    </loc>
+    <loc>https://ref--repo--owner.hlx.live/</loc>
     <lastmod>2023-11-30</lastmod>
   </url>
   <url>
-    <loc>
-      https://ref--repo--owner.hlx.live/test
-    </loc>
+    <loc>https://ref--repo--owner.hlx.live/test</loc>
     <lastmod>2023-12-21</lastmod>
   </url>
 </urlset>`);


### PR DESCRIPTION
The current output, e.g.:
```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>
      https://mcqueen-residence.org/
    </loc>
    <lastmod>2021-09-18</lastmod>
  </url>
</urlset>
```
could lead to issues.