### PR TITLE
fix: remove head fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-html-pipeline",
-  "version": "6.7.9",
+  "version": "6.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-html-pipeline",
-      "version": "6.7.9",
+      "version": "6.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "7.1.2",

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -80,7 +80,7 @@ export default async function render(state, req, res) {
     $head.children.push(...$headHtml.children);
   } else {
     appendElement($head, createElement('meta', 'name', 'viewport', 'content', 'width=device-width, initial-scale=1'));
-    appendElement($head, createElement('script', 'src', '/scripts/lib-franklin.js', 'type', 'module'));
+    appendElement($head, createElement('script', 'src', '/scripts/aem.js', 'type', 'module'));
     appendElement($head, createElement('script', 'src', '/scripts/scripts.js', 'type', 'module'));
     appendElement($head, createElement('link', 'rel', 'stylesheet', 'href', '/styles/styles.css'));
   }

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -80,8 +80,9 @@ export default async function render(state, req, res) {
     $head.children.push(...$headHtml.children);
   } else {
     appendElement($head, createElement('meta', 'name', 'viewport', 'content', 'width=device-width, initial-scale=1'));
-    appendElement($head, createElement('script', 'src', '/scripts.js', 'type', 'module', 'crossorigin', 'use-credentials'));
-    appendElement($head, createElement('link', 'rel', 'stylesheet', 'href', '/styles.css'));
+    appendElement($head, createElement('script', 'src', '/scripts/lib-franklin.js', 'type', 'module'));
+    appendElement($head, createElement('script', 'src', '/scripts/scripts.js', 'type', 'module'));
+    appendElement($head, createElement('link', 'rel', 'stylesheet', 'href', '/styles/styles.css'));
   }
 
   res.document = {

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -78,11 +78,6 @@ export default async function render(state, req, res) {
       .use(rehypeParse, { fragment: true })
       .parse(headHtml);
     $head.children.push(...$headHtml.children);
-  } else {
-    appendElement($head, createElement('meta', 'name', 'viewport', 'content', 'width=device-width, initial-scale=1'));
-    appendElement($head, createElement('script', 'src', '/scripts/aem.js', 'type', 'module'));
-    appendElement($head, createElement('script', 'src', '/scripts/scripts.js', 'type', 'module'));
-    appendElement($head, createElement('link', 'rel', 'stylesheet', 'href', '/styles/styles.css'));
   }
 
   res.document = {

--- a/test/fixtures/content/no-head-html.html
+++ b/test/fixtures/content/no-head-html.html
@@ -14,10 +14,6 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="/scripts/aem.js" type="module"></script>
-    <script src="/scripts/scripts.js" type="module"></script>
-    <link rel="stylesheet" href="/styles/styles.css"/>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/no-head-html.html
+++ b/test/fixtures/content/no-head-html.html
@@ -15,7 +15,7 @@
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="/scripts/lib-franklin.js" type="module"></script>
+    <script src="/scripts/aem.js" type="module"></script>
     <script src="/scripts/scripts.js" type="module"></script>
     <link rel="stylesheet" href="/styles/styles.css"/>
 </head>

--- a/test/fixtures/content/no-head-html.html
+++ b/test/fixtures/content/no-head-html.html
@@ -15,8 +15,9 @@
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="/scripts.js" type="module" crossorigin="use-credentials"></script>
-    <link rel="stylesheet" href="/styles.css">
+    <script src="/scripts/lib-franklin.js" type="module"></script>
+    <script src="/scripts/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles/styles.css"/>
 </head>
 <body>
 <header></header>


### PR DESCRIPTION
Update the fallback logic for missing `head.html` to support newer helix projects. 

🚨 Not sure if older projects are utilizing this fallback.