### PR TITLE
feat: support dynamic and configurable robots.txt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export * from './html-pipe.js';
 export * from './json-pipe.js';
 export * from './auth-pipe.js';
 export * from './options-pipe.js';
+export * from './robots-pipe.js';
 export * from './sitemap-pipe.js';
 export * from './PipelineContent.js';
 export * from './PipelineRequest.js';

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -48,6 +48,24 @@ Disallow: /
 `;
 
 /**
+ * Internal domains, either inner or outer CDN.
+ */
+const INTERNAL_DOMAINS = [
+  '.aem.page',
+  '.aem-fastly.page',
+  '.aem-cloudflare.page',
+  '.aem.live',
+  '.aem-fastly.live',
+  '.aem-cloudflare.live',
+  '.hlx.page',
+  '.hlx-fastly.page',
+  '.hlx-cloudflare.page',
+  '.hlx.live',
+  '.hlx-fastly.live',
+  '.hlx-cloudflare.live',
+];
+
+/**
  * Generate dynamic robots.txt with production host in the sitemap.
  *
  * @param {import('./PipelineState.js').PipelineState} state state
@@ -133,7 +151,7 @@ export async function robotsPipe(state, req) {
   const { partition } = state;
   const forwardedHosts = getForwardedHosts(req);
 
-  if (partition === 'preview' || forwardedHosts.every((host) => host.match(/^.+\.aem(?:-fastly)?\.(?:page|live)$/))) {
+  if (partition === 'preview' || forwardedHosts.every((host) => INTERNAL_DOMAINS.some((domain) => host.endsWith(domain)))) {
     // return default robots.txt, vary and no surrogate key
     res.body = DEFAULT_ROBOTS;
     res.headers.set('vary', 'x-forwarded-host');

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -82,7 +82,7 @@ function getForwardedHosts(req) {
   if (!xfh) {
     return [];
   }
-  return xfh.split(',').map((v) => v.trim());
+  return xfh.split(',').map((v) => v.trim()).filter((v) => !!v);
 }
 
 /**

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -48,7 +48,8 @@ Disallow: /
 `;
 
 /**
- * Internal domains, either inner or outer CDN.
+ * Internal domains, either inner or outer CDN. Every host that
+ * ends with one of those is considered internal.
  */
 const INTERNAL_DOMAINS = [
   '.aem.page',

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -78,8 +78,11 @@ function generateRobots(state) {
  * @returns {Array<String>} array of hosts
  */
 function getForwardedHosts(req) {
-  return (req.headers.get('x-forwarded-host') || '')
-    .split(',').map((v) => v.trim());
+  const xfh = req.headers.get('x-forwarded-host');
+  if (!xfh) {
+    return [];
+  }
+  return xfh.split(',').map((v) => v.trim());
 }
 
 /**

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -17,6 +17,33 @@ import { PipelineStatusError } from './PipelineStatusError.js';
 import { PipelineResponse } from './PipelineResponse.js';
 import initConfig from './steps/init-config.js';
 
+const DEFAULT_ROBOTS = `# Franklin robots.txt FAQ
+#
+# Q: This looks like a default robots.txt, how can I provide my own?
+# A: Put a file named robots.txt into the root of your GitHub
+# repo, Franklin will serve it from there.
+#
+# Q: Why am I'm seeing this robots.txt instead of the one I
+# configured?
+# A: You are visiting from *.aem.page or *.aem.live - in order
+# to prevent these sites from showing up in search engines and
+# giving you a duplicate content penalty on your real site we
+# exclude all robots
+#
+# Q: What do you mean with "real site"?
+# A: If you add a custom domain to this site (e.g.
+# example.com), then Franklin detects that you are ready for
+# production and serves your own robots.txt - but only on
+# example.com
+#
+# Q: This does not answer my questions at all. What can I do?
+# A: head over to #franklin-chat on Slack or
+# github.com/adobe/helix-home/issues and ask your question
+# there.
+User-agent: *
+Disallow: /
+`;
+
 function generateRobots(state) {
   const {
     prodHost,
@@ -33,6 +60,11 @@ function generateRobots(state) {
       'content-type': 'text/plain; charset=utf-8',
     },
   });
+}
+
+function getForwardedHosts(req) {
+  return (req.headers.get('x-forwarded-host') || '')
+    .split(',').map((v) => v.trim());
 }
 
 async function computeSurrogateKeys(state) {
@@ -73,6 +105,16 @@ export async function robotsPipe(state, req) {
       'content-type': 'text/plain; charset=utf-8',
     },
   });
+
+  // server internal robots.txt in inner or outer CDN
+  const { partition } = state;
+  const forwardedHosts = getForwardedHosts(req);
+
+  if (partition === 'preview' || forwardedHosts.every((host) => host.match(/[^,]*\.aem(?:-fastly)?\.(?:page|live)/))) {
+    res.body = DEFAULT_ROBOTS;
+    res.headers.set('vary', 'x-forwarded-host');
+    return res;
+  }
 
   try {
     await initConfig(state, req, res);

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -105,6 +105,7 @@ export async function robotsPipe(state, req) {
     // set surrogate keys
     const keys = await computeSurrogateKeys(state);
     res.headers.set('x-surrogate-key', keys.join(' '));
+    res.headers.set('vary', 'x-forwarded-host');
 
     await setCustomResponseHeaders(state, req, res);
   } catch (e) {

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -48,7 +48,7 @@ Disallow: /
 `;
 
 /**
- * Internal domains, either inner or outer CDN. Every host that
+ * Internal domains suffixes, either inner or outer CDN. Every host that
  * ends with one of those is considered internal.
  */
 const INTERNAL_DOMAINS = [
@@ -64,6 +64,13 @@ const INTERNAL_DOMAINS = [
   '.hlx.live',
   '.hlx-fastly.live',
   '.hlx-cloudflare.live',
+];
+
+/**
+ * Hosts that should not be treated as internal.
+ */
+const EXCLUDED_HOSTS = [
+  'www.aem.live',
 ];
 
 /**
@@ -152,7 +159,10 @@ export async function robotsPipe(state, req) {
   const { partition } = state;
   const forwardedHosts = getForwardedHosts(req);
 
-  if (partition === 'preview' || forwardedHosts.every((host) => INTERNAL_DOMAINS.some((domain) => host.endsWith(domain)))) {
+  if (partition === 'preview' || forwardedHosts.every(
+    (host) => !EXCLUDED_HOSTS.includes(host)
+      && INTERNAL_DOMAINS.some((domain) => host.endsWith(domain)),
+  )) {
     // return default robots.txt, vary and no surrogate key
     res.body = DEFAULT_ROBOTS;
     res.headers.set('vary', 'x-forwarded-host');

--- a/src/robots-pipe.js
+++ b/src/robots-pipe.js
@@ -127,11 +127,10 @@ export async function robotsPipe(state, req) {
     },
   });
 
-  // server internal robots.txt in inner or outer CDN
   const { partition } = state;
   const forwardedHosts = getForwardedHosts(req);
 
-  if (partition === 'preview' || forwardedHosts.every((host) => host.match(/[^,]*\.aem(?:-fastly)?\.(?:page|live)/))) {
+  if (partition === 'preview' || forwardedHosts.every((host) => host.match(/^.+\.aem(?:-fastly)?\.(?:page|live)$/))) {
     // return default robots.txt, vary and no surrogate key
     res.body = DEFAULT_ROBOTS;
     res.headers.set('vary', 'x-forwarded-host');

--- a/test/robots-pipe.test.js
+++ b/test/robots-pipe.test.js
@@ -79,7 +79,7 @@ describe('Robots Pipe Test', () => {
     assert.strictEqual(resp.status, 200);
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
-      'x-surrogate-key': 'roSNx5dktoCnqRXk foobar_metadata ref--repo--owner_head',
+      'x-surrogate-key': 'U_NW4adJU7Qazf-I ref--repo--owner_robots.txt ZcR1sjWODctSccZh',
     });
     assert.strictEqual(resp.body, 'this is my robots.txt');
   });
@@ -106,7 +106,7 @@ describe('Robots Pipe Test', () => {
     assert.strictEqual(resp.status, 200);
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
-      'x-surrogate-key': 'roSNx5dktoCnqRXk foobar_metadata ref--repo--owner_head',
+      'x-surrogate-key': 'U_NW4adJU7Qazf-I ref--repo--owner_robots.txt ZcR1sjWODctSccZh',
     });
     assert.strictEqual(resp.body, `User-Agent: *
 Allow: /

--- a/test/robots-pipe.test.js
+++ b/test/robots-pipe.test.js
@@ -184,7 +184,7 @@ Sitemap: https://www.example.com/sitemap.xml`);
           ...DEFAULT_CONFIG,
           cdn: {
             prod: {
-              host: 'www.example.com',
+              host: 'www.aem.live',
             },
           },
         },
@@ -209,7 +209,7 @@ Sitemap: https://www.example.com/sitemap.xml`);
     assert.strictEqual(resp.body, `User-Agent: *
 Allow: /
 
-Sitemap: https://www.example.com/sitemap.xml`);
+Sitemap: https://www.aem.live/sitemap.xml`);
   });
 
   it('handles pipeline errors', async () => {

--- a/test/robots-pipe.test.js
+++ b/test/robots-pipe.test.js
@@ -130,7 +130,7 @@ describe('Robots Pipe Test', () => {
       }),
       new PipelineRequest(new URL('https://www.hlx.live/'), {
         headers: {
-          'x-forwarded-host': 'main--repo--owner.aem-fastly.live, main--repo--owner.aem.live',
+          'x-forwarded-host': ',,,, main--repo--owner.aem-fastly.live, main--repo--owner.aem.live',
         },
       }),
     );

--- a/test/robots-pipe.test.js
+++ b/test/robots-pipe.test.js
@@ -79,6 +79,7 @@ describe('Robots Pipe Test', () => {
     assert.strictEqual(resp.status, 200);
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
+      vary: 'x-forwarded-host',
       'x-surrogate-key': 'U_NW4adJU7Qazf-I ref--repo--owner_robots.txt ZcR1sjWODctSccZh',
     });
     assert.strictEqual(resp.body, 'this is my robots.txt');
@@ -106,6 +107,7 @@ describe('Robots Pipe Test', () => {
     assert.strictEqual(resp.status, 200);
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
+      vary: 'x-forwarded-host',
       'x-surrogate-key': 'U_NW4adJU7Qazf-I ref--repo--owner_robots.txt ZcR1sjWODctSccZh',
     });
     assert.strictEqual(resp.body, `User-Agent: *

--- a/test/robots-pipe.test.js
+++ b/test/robots-pipe.test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { FileS3Loader } from './FileS3Loader.js';
+import {
+  robotsPipe, PipelineRequest, PipelineState,
+} from '../src/index.js';
+
+const DEFAULT_CONFIG = {
+  contentBusId: 'foobar',
+  owner: 'owner',
+  repo: 'repo',
+};
+
+const DEFAULT_STATE = (opts = {}) => (new PipelineState({
+  config: DEFAULT_CONFIG,
+  site: 'site',
+  org: 'org',
+  ref: 'ref',
+  partition: 'live',
+  s3Loader: new FileS3Loader(),
+  ...opts,
+}));
+
+describe('Robots Pipe Test', () => {
+  it('responds with 500 for non robots', async () => {
+    const resp = await robotsPipe(
+      DEFAULT_STATE(),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 500);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'x-error': 'invalid route',
+    });
+  });
+
+  it('responds with 500 for code-bus errors', async () => {
+    const resp = await robotsPipe(
+      DEFAULT_STATE({
+        s3Loader: new FileS3Loader().status('robots.txt', 500),
+        path: '/robots.txt',
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 502);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-error': 'failed to load /robots.txt from code-bus: 500',
+    });
+  });
+
+  it('renders robots from a configured robots entry', async () => {
+    const resp = await robotsPipe(
+      DEFAULT_STATE({
+        config: {
+          ...DEFAULT_CONFIG,
+          robots: {
+            txt: 'this is my robots.txt',
+          },
+        },
+        s3Loader: new FileS3Loader()
+          .status('robots.txt', 404),
+        path: '/robots.txt',
+        partition: 'live',
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 200);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-surrogate-key': 'roSNx5dktoCnqRXk foobar_metadata ref--repo--owner_head',
+    });
+    assert.strictEqual(resp.body, 'this is my robots.txt');
+  });
+
+  it('renders robots from live with prod CDN', async () => {
+    const resp = await robotsPipe(
+      DEFAULT_STATE({
+        config: {
+          ...DEFAULT_CONFIG,
+          cdn: {
+            prod: {
+              host: 'www.adobe.com',
+            },
+          },
+        },
+        s3Loader: new FileS3Loader()
+          .status('robots.txt', 404),
+        path: '/robots.txt',
+        partition: 'live',
+        timer: { update: () => {} },
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+    assert.strictEqual(resp.status, 200);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-surrogate-key': 'roSNx5dktoCnqRXk foobar_metadata ref--repo--owner_head',
+    });
+    assert.strictEqual(resp.body, `User-Agent: *
+Allow: /
+
+Sitemap: https://www.adobe.com/sitemap.xml`);
+  });
+
+  it('handles pipeline errors', async () => {
+    const resp = await robotsPipe(
+      DEFAULT_STATE({
+        path: '/robots.txt',
+        timer: {
+          update: () => {
+            throw new Error('boom!');
+          },
+        },
+      }),
+      new PipelineRequest(new URL('https://www.hlx.live/')),
+    );
+
+    assert.strictEqual(resp.status, 500);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-error': 'boom!',
+    });
+    assert.strictEqual(resp.body, '');
+  });
+});


### PR DESCRIPTION
To replace the VCL in aem.page/live to return the internal `robots.txt` on preview, inner and outer CDN