### PR TITLE
fix: icon regex to allow numbers to have a hyphen following as longs as that follows with another character

### DIFF
--- a/src/steps/rewrite-icons.js
+++ b/src/steps/rewrite-icons.js
@@ -13,7 +13,7 @@
 import { h } from 'hastscript';
 import { CONTINUE, SKIP, visit } from 'unist-util-visit';
 
-const REGEXP_ICON = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
+const REGEXP_ICON = /(?<!(?:https?|urn)[^\s]*):(#?[a-z][a-z\d_-]+[a-z\d]):/gi;
 
 /**
  * Create a <span> icon element:

--- a/test/fixtures/content/icons-ignored.html
+++ b/test/fixtures/content/icons-ignored.html
@@ -5,5 +5,7 @@
         <pre><code>:rocket:</code></pre>
         <p><a href="https://example.test/:urn:">https://example.test/:urn:</a></p>
         <p>urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8</p>
+        <p>:red-check-mark-:</p>
+        <p>:be:</p>
     </div>
 </main>

--- a/test/fixtures/content/icons-ignored.md
+++ b/test/fixtures/content/icons-ignored.md
@@ -9,3 +9,7 @@
 [https://example.test/:urn:](https://example.test/:urn:)
 
 urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8
+
+:red-check-mark-:
+
+:be:

--- a/test/fixtures/content/icons.html
+++ b/test/fixtures/content/icons.html
@@ -5,5 +5,8 @@
         <p>Hello <span class="icon icon-red"></span> banner.</p>
         <p>Hello <span class="icon icon-check"></span> mark.</p>
         <p>Team<span class="icon icon-rocket"></span>blasting off again.</p>
+        <p><span class="icon icon-red-check-mark"></span></p>
+        <p><span class="icon icon-red-check-1"></span></p>
+        <p><span class="icon icon-red-check-2-mark"></span></p>
     </div>
 </main>

--- a/test/fixtures/content/icons.md
+++ b/test/fixtures/content/icons.md
@@ -7,3 +7,9 @@ Hello :red: banner.
 Hello :#check: mark.
 
 Team:rocket:blasting off again.
+
+:red-check-mark:
+
+:red-check-1:
+
+:red-check-2-mark:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

Current code will not allow this:

`:my-icon-1-one:`

the number cannot have a hyphen after it. PR corrects this.

## Related Issues


Thanks for contributing!
