### PR TITLE
fix: scoped keys for prefix content (DON'T BACKPORT TO V5)

### DIFF
--- a/src/json-pipe.js
+++ b/src/json-pipe.js
@@ -67,7 +67,7 @@ async function fetchJsonContent(state, req, res) {
       keys.push(contentBusId);
       const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
       if (partition === 'preview') {
-        // temprarily provide additional preview content keys
+        // temporarily provide additional preview content keys
         // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
         keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${contentBusId}${info.path}`)}`);
         keys.push(`${contentKeyPrefix}${contentBusId}`);
@@ -113,7 +113,7 @@ async function computeSurrogateKeys(state) {
     keys.push(state.contentBusId);
     const contentKeyPrefix = state.partition === 'preview' ? 'p_' : '';
     if (state.partition === 'preview') {
-      // temprarily provide additional preview content keys
+      // temporarily provide additional preview content keys
       // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
       keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${state.contentBusId}${state.info.path}`)}`);
       keys.push(`${contentKeyPrefix}${state.contentBusId}`);

--- a/src/json-pipe.js
+++ b/src/json-pipe.js
@@ -65,6 +65,13 @@ async function fetchJsonContent(state, req, res) {
     if (state.content.sourceBus === 'content') {
       keys.push(await computeSurrogateKey(`${contentBusId}${info.path}`));
       keys.push(contentBusId);
+      const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
+      if (partition === 'preview') {
+        // temprarily provide additional preview content keys
+        // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
+        keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${contentBusId}${info.path}`)}`);
+        keys.push(`${contentKeyPrefix}${contentBusId}`);
+      }
     } else {
       keys.push(`${ref}--${repo}--${owner}_code`);
       keys.push(await computeSurrogateKey(`${ref}--${repo}--${owner}${info.path}`));
@@ -104,6 +111,13 @@ async function computeSurrogateKeys(state) {
   if (state.content.sourceBus.includes('content')) {
     keys.push(await computeSurrogateKey(`${state.contentBusId}${state.info.path}`));
     keys.push(state.contentBusId);
+    const contentKeyPrefix = state.partition === 'preview' ? 'p_' : '';
+    if (state.partition === 'preview') {
+      // temprarily provide additional preview content keys
+      // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
+      keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${state.contentBusId}${state.info.path}`)}`);
+      keys.push(`${contentKeyPrefix}${state.contentBusId}`);
+    }
   }
 
   return keys;

--- a/src/steps/fetch-404.js
+++ b/src/steps/fetch-404.js
@@ -48,7 +48,7 @@ export default async function fetch404(state, req, res) {
   ];
   const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
   if (partition === 'preview') {
-    // temprarily provide additional preview content keys
+    // temporarily provide additional preview content keys
     // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
     keys.push(`${contentKeyPrefix}${pathKey}`);
     keys.push(`${contentKeyPrefix}${contentBusId}`);
@@ -61,7 +61,7 @@ export default async function fetch404(state, req, res) {
     });
     keys.push(unmappedPathKey);
     if (partition === 'preview') {
-      // temprarily provide additional preview content key
+      // temporarily provide additional preview content key
       // TODO: eventually provide either (prefixed) preview or (unprefixed) live content key
       keys.push(`${contentKeyPrefix}${unmappedPathKey}`);
     }

--- a/src/steps/fetch-content.js
+++ b/src/steps/fetch-content.js
@@ -48,6 +48,13 @@ export default async function fetchContent(state, req, res) {
     } else {
       keys.push(await computeSurrogateKey(`${contentBusId}${info.path}`));
       keys.push(contentBusId);
+      const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
+      if (partition === 'preview') {
+        // temprarily provide additional preview content keys
+        // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
+        keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${contentBusId}${info.path}`)}`);
+        keys.push(`${contentKeyPrefix}${contentBusId}`);
+      }
     }
     res.headers.set('x-surrogate-key', keys.join(' '));
     res.error = 'moved';

--- a/src/steps/fetch-content.js
+++ b/src/steps/fetch-content.js
@@ -50,7 +50,7 @@ export default async function fetchContent(state, req, res) {
       keys.push(contentBusId);
       const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
       if (partition === 'preview') {
-        // temprarily provide additional preview content keys
+        // temporarily provide additional preview content keys
         // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
         keys.push(`${contentKeyPrefix}${await computeSurrogateKey(`${contentBusId}${info.path}`)}`);
         keys.push(`${contentKeyPrefix}${contentBusId}`);

--- a/src/steps/set-x-surrogate-key-header.js
+++ b/src/steps/set-x-surrogate-key-header.js
@@ -59,7 +59,7 @@ export default async function setXSurrogateKeyHeader(state, req, res) {
     keys.push(`${ref}--${repo}--${owner}_head`);
     keys.push(contentBusId);
     if (partition === 'preview') {
-      // temprarily provide additional preview content keys
+      // temporarily provide additional preview content keys
       // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
       keys.push(`${contentKeyPrefix}${hash}`);
       keys.push(`${contentKeyPrefix}${contentBusId}_metadata`);
@@ -76,7 +76,7 @@ export default async function setXSurrogateKeyHeader(state, req, res) {
       }));
     }
     if (partition === 'preview') {
-      // temprarily provide additional preview content keys
+      // temporarily provide additional preview content keys
       // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
       keys.push(`${contentKeyPrefix}${hash}_metadata`);
       if (state.info.unmappedPath) {

--- a/src/steps/set-x-surrogate-key-header.js
+++ b/src/steps/set-x-surrogate-key-header.js
@@ -42,11 +42,12 @@ export async function getPathKey(state) {
  */
 export default async function setXSurrogateKeyHeader(state, req, res) {
   const {
-    contentBusId, owner, repo, ref,
+    contentBusId, owner, repo, ref, partition,
   } = state;
 
   const isCode = state.content.sourceBus === 'code';
 
+  const contentKeyPrefix = partition === 'preview' ? 'p_' : '';
   const keys = [];
   const hash = await getPathKey(state);
   if (isCode) {
@@ -57,6 +58,13 @@ export default async function setXSurrogateKeyHeader(state, req, res) {
     keys.push(`${contentBusId}_metadata`);
     keys.push(`${ref}--${repo}--${owner}_head`);
     keys.push(contentBusId);
+    if (partition === 'preview') {
+      // temprarily provide additional preview content keys
+      // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
+      keys.push(`${contentKeyPrefix}${hash}`);
+      keys.push(`${contentKeyPrefix}${contentBusId}_metadata`);
+      keys.push(`${contentKeyPrefix}${contentBusId}`);
+    }
   }
   // for folder-mapped resources, we also need to include the surrogate key of the mapped metadata
   if (state.mapped) {
@@ -66,6 +74,17 @@ export default async function setXSurrogateKeyHeader(state, req, res) {
         contentBusId,
         info: { path: state.info.unmappedPath },
       }));
+    }
+    if (partition === 'preview') {
+      // temprarily provide additional preview content keys
+      // TODO: eventually provide either (prefixed) preview or (unprefixed) live content keys
+      keys.push(`${contentKeyPrefix}${hash}_metadata`);
+      if (state.info.unmappedPath) {
+        keys.push(`${contentKeyPrefix}${await getPathKey({
+          contentBusId,
+          info: { path: state.info.unmappedPath },
+        })}`);
+      }
     }
   }
   res.headers.set('x-surrogate-key', keys.join(' '));

--- a/test/sitemap-pipe.test.js
+++ b/test/sitemap-pipe.test.js
@@ -74,7 +74,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
       'x-error': 'failed to load /sitemap.xml from content-bus: 404',
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
   });
 
@@ -92,7 +92,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
       'x-error': 'Failed to parse /sitemap.json: Unexpected token \'h\', "this is not JSON" is not valid JSON',
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
   });
 
@@ -110,7 +110,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
       'x-error': "Expected 'data' array not found in /sitemap.json",
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
   });
 
@@ -128,7 +128,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/xml; charset=utf-8',
       'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
     assert.strictEqual(resp.body, `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
     <url>
@@ -154,7 +154,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/xml; charset=utf-8',
       'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
@@ -190,7 +190,7 @@ describe('Sitemap Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/xml; charset=utf-8',
       'last-modified': 'Fri, 30 Apr 2021 03:47:18 GMT',
-      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar',
+      'x-surrogate-key': 'RXei-6EcTEMTEIqi foobar_metadata ref--repo--owner_head foobar p_RXei-6EcTEMTEIqi p_foobar_metadata p_foobar',
     });
     assert.strictEqual(resp.body, `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Temporarily provide additional preview content keys (prefixed by `p_`)
       
Eventually, i.e. once prefixed preview keys have been deployed and admin purge has been changed to purge prefixed keys only on preview,  provide either prefixed preview or unprefixed live content keys.
 
