### PR TITLE
fix: avoid icon rewrite of hh:mm:ss and similar

### DIFF
--- a/src/steps/rewrite-icons.js
+++ b/src/steps/rewrite-icons.js
@@ -13,7 +13,7 @@
 import { h } from 'hastscript';
 import { CONTINUE, SKIP, visit } from 'unist-util-visit';
 
-const REGEXP_ICON = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
+const REGEXP_ICON = /(?<!https?:\/\/[^\s]*):(#?[a-z_\d-]+):(?!\w)/gi;
 
 /**
  * Create a <span> icon element:

--- a/test/fixtures/content/icons-ignored.html
+++ b/test/fixtures/content/icons-ignored.html
@@ -5,5 +5,6 @@
         <pre><code>:rocket:</code></pre>
         <p><a href="https://example.test/:urn:">https://example.test/:urn:</a></p>
         <p>urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8</p>
+        <p>please specify time in <strong>hh:mm:ss</strong> format.</p>
     </div>
 </main>

--- a/test/fixtures/content/icons-ignored.md
+++ b/test/fixtures/content/icons-ignored.md
@@ -9,3 +9,5 @@
 [https://example.test/:urn:](https://example.test/:urn:)
 
 urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8
+
+please specify time in **hh:mm:ss** format.

--- a/test/fixtures/content/icons.html
+++ b/test/fixtures/content/icons.html
@@ -4,6 +4,10 @@
         <p>Hello <span class="icon icon-button"></span></p>
         <p>Hello <span class="icon icon-red"></span> banner.</p>
         <p>Hello <span class="icon icon-check"></span> mark.</p>
-        <p>Team<span class="icon icon-rocket"></span>blasting off again.</p>
+        <p>Team:rocket:blasting off again.</p>
+        <p><span class="icon icon-red-check-mark"></span></p>
+        <p><span class="icon icon-red-check-1"></span></p>
+        <p><span class="icon icon-red-check-2-mark"></span></p>
+        <p><span class="icon icon-red-check-mark-"></span></p>
     </div>
 </main>

--- a/test/fixtures/content/icons.md
+++ b/test/fixtures/content/icons.md
@@ -7,3 +7,12 @@ Hello :red: banner.
 Hello :#check: mark.
 
 Team:rocket:blasting off again.
+
+:red-check-mark:
+
+:red-check-1:
+
+:red-check-2-mark:
+
+:red-check-mark-:
+

--- a/test/steps/rewrite-icons.test.js
+++ b/test/steps/rewrite-icons.test.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import { toHtml } from 'hast-util-to-html';
+import rewrite from '../../src/steps/rewrite-icons.js';
+
+describe('Rewrite Icons Step', () => {
+  it('rewrites the icons correctly', () => {
+    /** @type PipelineState */
+    const state = {
+      log: console,
+      content: {
+        hast: {
+          type: 'element',
+          tagName: 'div',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a :smile:. and another :funny-123-icon: icon.',
+            },
+            {
+              type: 'text',
+              value: 'Hello :#check: mark.',
+            },
+            {
+              type: 'text',
+              value: ':red-check-mark-:',
+            },
+            {
+              type: 'text',
+              value: 'Team:rocket:blasting off again.',
+            },
+            {
+              type: 'element',
+              tagName: 'p',
+              children: [
+                {
+                  type: 'text',
+                  value: ':button:',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    rewrite(state);
+    const html = toHtml(state.content.hast);
+    assert.strictEqual(html, '<div>'
+      + 'This is a <span class="icon icon-smile"></span>.'
+      + ' and another <span class="icon icon-funny-123-icon"></span> icon.'
+      + 'Hello <span class="icon icon-check"></span> mark.'
+      + '<span class="icon icon-red-check-mark-"></span>'
+      + 'Team:rocket:blasting off again.'
+      + '<p><span class="icon icon-button"></span></p>'
+      + '</div>');
+  });
+
+  it('ignores some pattern correctly', () => {
+    /** @type PipelineState */
+    const state = {
+      log: console,
+      content: {
+        hast: {
+          type: 'element',
+          tagName: 'div',
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              children: [
+                {
+                  type: 'text',
+                  value: 'code is not icons :smile:',
+                },
+              ],
+            },
+            {
+              type: 'text',
+              value: 'This url: https://example.test/:urn: is no an icon.',
+            },
+            {
+              type: 'text',
+              value: 'neither is this: urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8 an icon.',
+            },
+            {
+              type: 'text',
+              value: 'Also not this:  hh:mm:ss',
+            },
+          ],
+        },
+      },
+    };
+    rewrite(state);
+    const html = toHtml(state.content.hast);
+    assert.strictEqual(html, '<div>'
+      + '<code>code is not icons :smile:</code>'
+      + 'This url: https://example.test/:urn: is no an icon.'
+      + 'neither is this: urn:aaid:sc:VA6C2:ac6066f3-fd1d-4e00-bed3-fa3aa6d981d8 an icon.'
+      + 'Also not this:  hh:mm:ss'
+      + '</div>');
+  });
+});


### PR DESCRIPTION
potential regression: if there is no non-word character around the `:icon:`, it will no longer rewrite. eg:

my:smile:is bright.

`Team:rocket:blasting off again`

but github markdown doesn't detect it neither:

my:smile:is bright.

