### PR TITLE
feat: respect last-modified from metadata sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lodash.escape": "4.0.1",
         "mdast-util-to-hast": "13.2.0",
         "mdast-util-to-string": "4.0.0",
+        "micromark-util-subtokenize": "2.0.1",
         "mime": "4.0.4",
         "rehype-format": "5.0.1",
         "rehype-parse": "9.0.1",
@@ -2486,9 +2487,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3811,9 +3812,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6762,9 +6763,9 @@
       }
     },
     "node_modules/micromark-util-subtokenize": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.2.tgz",
-      "integrity": "sha512-xKxhkB62vwHUuuxHe9Xqty3UaAsizV2YKq5OV344u3hFBbf8zIYrhYOWhAQb94MtMPkjTOzzjJ/hid9/dR5vFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.1.tgz",
+      "integrity": "sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-html-pipeline",
-  "version": "6.15.7",
+  "version": "6.15.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-html-pipeline",
-      "version": "6.15.7",
+      "version": "6.15.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.escape": "4.0.1",
     "mdast-util-to-hast": "13.2.0",
     "mdast-util-to-string": "4.0.0",
+    "micromark-util-subtokenize": "2.0.1",
     "mime": "4.0.4",
     "rehype-format": "5.0.1",
     "rehype-parse": "9.0.1",

--- a/src/PipelineResponse.js
+++ b/src/PipelineResponse.js
@@ -30,7 +30,7 @@ export class PipelineResponse {
       document: undefined,
       headers,
       error: undefined,
-      lastModifiedTime: 0,
+      lastModifiedSources: {},
     });
   }
 

--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -35,7 +35,7 @@ import { PipelineStatusError } from './PipelineStatusError.js';
 import { PipelineResponse } from './PipelineResponse.js';
 import { validatePathInfo } from './utils/path.js';
 import fetchMappedMetadata from './steps/fetch-mapped-metadata.js';
-import { setLastModified } from './utils/last-modified.js';
+import { applyMetaLastModified, setLastModified } from './utils/last-modified.js';
 
 /**
  * Fetches the content and if not found, fetches the 404.html
@@ -168,6 +168,7 @@ export async function htmlPipe(state, req) {
       await render(state, req, res);
       state.timer?.update('serialize');
       await tohtml(state, req, res);
+      await applyMetaLastModified(state, res);
     }
 
     setLastModified(state, res);

--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -35,6 +35,7 @@ import { PipelineStatusError } from './PipelineStatusError.js';
 import { PipelineResponse } from './PipelineResponse.js';
 import { validatePathInfo } from './utils/path.js';
 import fetchMappedMetadata from './steps/fetch-mapped-metadata.js';
+import { setLastModified } from './utils/last-modified.js';
 
 /**
  * Fetches the content and if not found, fetches the 404.html
@@ -140,6 +141,7 @@ export async function htmlPipe(state, req) {
       log[level](`pipeline status: ${res.status} ${res.error}`);
       res.headers.set('x-error', cleanupHeaderValue(res.error));
       if (res.status < 500) {
+        setLastModified(state, res);
         await setCustomResponseHeaders(state, req, res);
       }
       return res;
@@ -168,6 +170,7 @@ export async function htmlPipe(state, req) {
       await tohtml(state, req, res);
     }
 
+    setLastModified(state, res);
     await setCustomResponseHeaders(state, req, res);
     await setXSurrogateKeyHeader(state, req, res);
   } catch (e) {

--- a/src/sitemap-pipe.js
+++ b/src/sitemap-pipe.js
@@ -18,7 +18,7 @@ import setCustomResponseHeaders from './steps/set-custom-response-headers.js';
 import { PipelineStatusError } from './PipelineStatusError.js';
 import { PipelineResponse } from './PipelineResponse.js';
 import initConfig from './steps/init-config.js';
-import { extractLastModified, updateLastModified } from './utils/last-modified.js';
+import { extractLastModified, recordLastModified, setLastModified } from './utils/last-modified.js';
 
 async function generateSitemap(state) {
   const {
@@ -103,7 +103,7 @@ export async function sitemapPipe(state, req) {
       const ret = await generateSitemap(state);
       if (ret.status === 200) {
         res.status = 200;
-        updateLastModified(state, res, extractLastModified(ret.headers));
+        recordLastModified(state, res, 'content', extractLastModified(ret.headers));
         delete res.error;
         state.content.data = ret.body;
       }
@@ -115,6 +115,7 @@ export async function sitemapPipe(state, req) {
 
     state.timer?.update('serialize');
     await renderCode(state, req, res);
+    setLastModified(state, res);
     await setCustomResponseHeaders(state, req, res);
     await setXSurrogateKeyHeader(state, req, res);
   } catch (e) {

--- a/src/steps/fetch-404.js
+++ b/src/steps/fetch-404.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { extractLastModified } from '../utils/last-modified.js';
+import { extractLastModified, recordLastModified } from '../utils/last-modified.js';
 import { getPathKey } from './set-x-surrogate-key-header.js';
 
 /**
@@ -29,7 +29,7 @@ export default async function fetch404(state, req, res) {
     // override last-modified if source-last-modified is set
     const lastModified = extractLastModified(ret.headers);
     if (lastModified) {
-      ret.headers.set('last-modified', lastModified);
+      recordLastModified(state, res, 'content', lastModified);
     }
 
     // keep 404 response status

--- a/src/steps/fetch-content.js
+++ b/src/steps/fetch-content.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { computeSurrogateKey } from '@adobe/helix-shared-utils';
-import { extractLastModified, updateLastModified } from '../utils/last-modified.js';
+import { extractLastModified, recordLastModified } from '../utils/last-modified.js';
 
 /**
  * Loads the content from either the content-bus or code-bus and stores it in `state.content`
@@ -65,7 +65,7 @@ export default async function fetchContent(state, req, res) {
     state.content.sourceLocation = ret.headers.get('x-amz-meta-x-source-location');
     log.info(`source-location: ${state.content.sourceLocation}`);
 
-    updateLastModified(state, res, extractLastModified(ret.headers));
+    recordLastModified(state, res, 'content', extractLastModified(ret.headers));
 
     // reject requests to /index *after* checking for redirects
     // (https://github.com/adobe/helix-pipeline-service/issues/290)

--- a/src/steps/fetch-mapped-metadata.js
+++ b/src/steps/fetch-mapped-metadata.js
@@ -12,7 +12,7 @@
 
 import { PipelineStatusError } from '../PipelineStatusError.js';
 import { Modifiers } from '../utils/modifiers.js';
-import { extractLastModified, updateLastModified } from '../utils/last-modified.js';
+import { extractLastModified, recordLastModified } from '../utils/last-modified.js';
 
 /**
  * Loads metadata for a mapped path and puts it into `state.mappedMetadata`. If path is not
@@ -53,7 +53,7 @@ export default async function fetchMappedMetadata(state, res) {
     state.mappedMetadata = Modifiers.fromModifierSheet(
       data,
     );
-    updateLastModified(state, res, extractLastModified(ret.headers));
+    recordLastModified(state, res, 'metadata', extractLastModified(ret.headers));
     return;
   }
   if (ret.status !== 404) {

--- a/src/steps/init-config.js
+++ b/src/steps/init-config.js
@@ -11,7 +11,7 @@
  */
 import { Modifiers } from '../utils/modifiers.js';
 import { getOriginalHost } from './utils.js';
-import { updateLastModified } from '../utils/last-modified.js';
+import { recordLastModified } from '../utils/last-modified.js';
 
 function replaceParams(str, info) {
   if (!str) {
@@ -44,5 +44,5 @@ export default function initConfig(state, req, res) {
   state.previewHost = replaceParams(config.cdn?.preview?.host, state);
   state.liveHost = replaceParams(config.cdn?.live?.host, state);
   state.prodHost = config.cdn?.prod?.host || getOriginalHost(req.headers);
-  updateLastModified(state, res, state.config.lastModified);
+  recordLastModified(state, res, 'config', state.config.lastModified);
 }

--- a/src/utils/last-modified.js
+++ b/src/utils/last-modified.js
@@ -14,7 +14,7 @@
  * Records the last modified for the given source.
  *
  * @param {PipelineState} state
- * @param {PipelineResponse} res the pipeline context
+ * @param {PipelineResponse} res the pipeline response
  * @param {string} source the source providing a last-modified date
  * @param {string} httpDate http-date string
  */
@@ -39,7 +39,7 @@ export function recordLastModified(state, res, source, httpDate) {
  * and sets it on the `last-modified` header.
  *
  * @param {PipelineState} state
- * @param {PipelineResponse} res the pipeline context
+ * @param {PipelineResponse} res the pipeline response
  */
 export function setLastModified(state, res) {
   let latestTime = 0;
@@ -67,4 +67,14 @@ export function extractLastModified(headers) {
     return lastModified;
   }
   return headers.get('last-modified');
+}
+
+/**
+ * Sets the metadata last modified entry to the one define in the page specific metadata if
+ * it exists. this allows to control the last-modified per metadata record.
+ * @param {PipelineState} state
+ * @param {PipelineResponse} res the pipeline response
+ */
+export function applyMetaLastModified(state, res) {
+  recordLastModified(state, res, 'metadata', state.content.meta.page['last-modified']);
 }

--- a/src/utils/last-modified.js
+++ b/src/utils/last-modified.js
@@ -11,30 +11,43 @@
  */
 
 /**
- * Updates the context.content.lastModified if the time in `timeString` is newer than the existing
- * one if none exists yet. please note that it generates helper property `lastModifiedTime` in
- * unix epoch format.
- *
- * the date string will be a "http-date": https://httpwg.org/specs/rfc7231.html#http.date
+ * Records the last modified for the given source.
  *
  * @param {PipelineState} state
  * @param {PipelineResponse} res the pipeline context
+ * @param {string} source the source providing a last-modified date
  * @param {string} httpDate http-date string
  */
-export function updateLastModified(state, res, httpDate) {
+export function recordLastModified(state, res, source, httpDate) {
   if (!httpDate) {
     return;
   }
   const { log } = state;
-  const time = new Date(httpDate).getTime();
-  if (Number.isNaN(time)) {
-    log.warn(`updateLastModified date is invalid: ${httpDate}`);
+  const date = new Date(httpDate);
+  if (Number.isNaN(date.valueOf())) {
+    log.warn(`last-modified date is invalid: ${httpDate} for ${source}`);
     return;
   }
+  res.lastModifiedSources[source] = {
+    time: date.valueOf(),
+    date: date.toUTCString(),
+  };
+}
 
-  if (time > (res.lastModifiedTime ?? 0)) {
-    res.lastModifiedTime = time;
-    res.headers.set('last-modified', httpDate);
+/**
+ * Calculates the last modified by using the latest date from all the recorded sources
+ * and sets it on the `last-modified` header.
+ *
+ * @param {PipelineState} state
+ * @param {PipelineResponse} res the pipeline context
+ */
+export function setLastModified(state, res) {
+  let latestTime = 0;
+  for (const { time, date } of Object.values(res.lastModifiedSources)) {
+    if (time > latestTime) {
+      latestTime = time;
+      res.headers.set('last-modified', date);
+    }
   }
 }
 

--- a/test/fixtures/content/generic-product/metadata.json
+++ b/test/fixtures/content/generic-product/metadata.json
@@ -60,6 +60,10 @@
         "Keywords": "Exactomento Mapped Folder",
         "og:publisher": "Adobe",
         "Short Title": "E"
+      },
+      {
+        "URL": "/products/product2",
+        "last-modified": "2024-12-25T03:33:33"
       }
     ]
   }

--- a/test/fixtures/content/generic-product/metadata.json
+++ b/test/fixtures/content/generic-product/metadata.json
@@ -63,7 +63,7 @@
       },
       {
         "URL": "/products/product2",
-        "last-modified": "2024-12-25T03:33:33"
+        "last-modified": "2024-12-25T03:33:33Z"
       }
     ]
   }

--- a/test/json-pipe.test.js
+++ b/test/json-pipe.test.js
@@ -105,7 +105,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         )
@@ -116,7 +116,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -149,7 +149,7 @@ describe('JSON Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
       'x-surrogate-key': 'p_Atrz_qDg26DmSe9a p_foobar',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
     });
     // live (code coverage)
     state.partition = 'live';
@@ -165,7 +165,7 @@ describe('JSON Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
       'x-surrogate-key': 'Atrz_qDg26DmSe9a foobar',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
     });
   });
 
@@ -221,7 +221,7 @@ describe('JSON Pipe Test', () => {
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
       'x-surrogate-key': 'p_Atrz_qDg26DmSe9a p_foobar',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
     });
   });
 
@@ -240,7 +240,7 @@ describe('JSON Pipe Test', () => {
     assert.deepStrictEqual(headers, {
       'access-control-allow-origin': '*',
       'content-security-policy': 'default-src \'self\'',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
       'x-surrogate-key': 'p_Atrz_qDg26DmSe9a p_foobar',
       'content-type': 'application/json',
     });
@@ -345,7 +345,7 @@ describe('JSON Pipe Test', () => {
     });
     const headers = Object.fromEntries(resp.headers.entries());
     assert.deepStrictEqual(headers, {
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
       'x-surrogate-key': 'p_Atrz_qDg26DmSe9a p_foobar',
       'content-type': 'application/json',
     });
@@ -360,7 +360,7 @@ describe('JSON Pipe Test', () => {
         headers: {
           'content-type': 'application/json',
           'x-amz-meta-x-source-location': 'foo-bar',
-          'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+          'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
           'x-amz-meta-x-source-last-modified': 'Wed, 12 Oct 2009 15:50:00 GMT',
         },
       }),
@@ -377,7 +377,7 @@ describe('JSON Pipe Test', () => {
     });
     const headers = Object.fromEntries(resp.headers.entries());
     assert.deepStrictEqual(headers, {
-      'last-modified': 'Wed, 12 Oct 2009 15:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 15:50:00 GMT',
       'x-surrogate-key': 'p_Atrz_qDg26DmSe9a p_foobar',
       'content-type': 'application/json',
     });
@@ -397,7 +397,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -413,7 +413,7 @@ describe('JSON Pipe Test', () => {
     });
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
       'x-surrogate-key': 'SIMSxecp2CJXqGYs ref--repo--owner_code',
     });
   });
@@ -435,7 +435,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -448,7 +448,7 @@ describe('JSON Pipe Test', () => {
     });
     assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
       'content-type': 'application/json',
-      'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+      'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
       'x-surrogate-key': 'SIMSxecp2CJXqGYs ref--repo--owner_code',
     });
   });
@@ -536,7 +536,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -563,7 +563,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -617,7 +617,7 @@ describe('JSON Pipe Test', () => {
             headers: {
               'content-type': 'application/json',
               'x-amz-meta-x-source-location': 'foo-bar',
-              'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+              'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
             },
           }),
         ),
@@ -636,7 +636,7 @@ describe('JSON Pipe Test', () => {
         headers: {
           'content-type': 'application/json',
           'x-amz-meta-x-source-location': 'foo-bar',
-          'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+          'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
         },
       }),
     );
@@ -671,7 +671,7 @@ describe('JSON Pipe Test', () => {
         headers: {
           'content-type': 'application/json',
           'x-amz-meta-x-source-location': 'foo-bar',
-          'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+          'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
         },
       }),
     );

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -526,11 +526,11 @@ describe('Rendering', () => {
     it('renders 404.html if content not found', async () => {
       loader
         .rewrite('404.html', 'super-test/404-test.html')
-        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Wed, 12 Oct 2009 17:50:00 GMT');
+        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
       const { body, headers } = await testRender('not-found-with-handler', 'html', 404);
       assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
         'content-type': 'text/html; charset=utf-8',
-        'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+        'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
         'x-surrogate-key': 'OYsA_wfqip5EuBu6 foo-id super-test--helix-pages--adobe_404 super-test--helix-pages--adobe_code',
         'x-error': 'failed to load /not-found-with-handler.md from content-bus: 404',
         'access-control-allow-origin': '*',
@@ -542,11 +542,11 @@ describe('Rendering', () => {
     it('renders 404.html if content not found for .plain.html', async () => {
       loader
         .rewrite('super-test/404.html', 'super-test/404-test.html')
-        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Wed, 12 Oct 2009 17:50:00 GMT');
+        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
       const { body, headers } = await testRender('not-found-with-handler.plain.html', 'html', 404);
       assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
         'content-type': 'text/html; charset=utf-8',
-        'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+        'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
         'x-surrogate-key': 'OYsA_wfqip5EuBu6 foo-id super-test--helix-pages--adobe_404 super-test--helix-pages--adobe_code',
         'x-error': 'failed to load /not-found-with-handler.md from content-bus: 404',
         'access-control-allow-origin': '*',
@@ -557,11 +557,11 @@ describe('Rendering', () => {
     it('renders 404.html if content not found for static html', async () => {
       loader
         .rewrite('super-test/404.html', 'super-test/404-test.html')
-        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Wed, 12 Oct 2009 17:50:00 GMT');
+        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
       const { body, headers } = await testRender('not-found-with-handler.html', 'html', 404);
       assert.deepStrictEqual(Object.fromEntries(headers.entries()), {
         'content-type': 'text/html; charset=utf-8',
-        'last-modified': 'Wed, 12 Oct 2009 17:50:00 GMT',
+        'last-modified': 'Mon, 12 Oct 2009 17:50:00 GMT',
         'x-error': 'failed to load /not-found-with-handler.html from code-bus: 404',
         'x-surrogate-key': 'ta3V7wR3zlRh1b0E foo-id super-test--helix-pages--adobe_404 super-test--helix-pages--adobe_code',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
@@ -718,7 +718,7 @@ describe('Rendering', () => {
 
     it('respect metadata with folder mapping: self and descendents', async () => {
       loader
-        .headers('generic-product/metadata.json', 'last-modified', 'Thu Nov 07 2024 00:00:00 GMT+0000');
+        .headers('generic-product/metadata.json', 'last-modified', 'Thu, 07 Nov 2024 00:00:00 GMT');
 
       let resp = await render(new URL('https://helix-pipeline.com/products'));
       assert.strictEqual(resp.status, 200);
@@ -734,7 +734,7 @@ describe('Rendering', () => {
       assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
         'access-control-allow-origin': '*',
         'content-type': 'text/html; charset=utf-8',
-        'last-modified': 'Thu Nov 07 2024 00:00:00 GMT+0000',
+        'last-modified': 'Thu, 07 Nov 2024 00:00:00 GMT',
         'x-surrogate-key': 'AkcHu8fRFT7HarTR foo-id_metadata super-test--helix-pages--adobe_head foo-id AkcHu8fRFT7HarTR_metadata z8NGXvKB0X5Fzcnd',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
       });

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -738,6 +738,20 @@ describe('Rendering', () => {
         'x-surrogate-key': 'AkcHu8fRFT7HarTR foo-id_metadata super-test--helix-pages--adobe_head foo-id AkcHu8fRFT7HarTR_metadata z8NGXvKB0X5Fzcnd',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
       });
+
+      // product2 has a custom last-modified defined in the metadata
+      resp = await render(new URL('https://helix-pipeline.com/products/product2'));
+      assert.strictEqual(resp.status, 200);
+      assert.match(resp.body, /<meta name="short-title" content="E">/);
+      assert.match(resp.body, /<meta property="og:publisher" content="Adobe">/);
+      assert.match(resp.body, /<meta name="keywords" content="Exactomento Mapped Folder">/);
+      assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
+        'access-control-allow-origin': '*',
+        'content-type': 'text/html; charset=utf-8',
+        'last-modified': 'Wed, 25 Dec 2024 02:33:33 GMT',
+        'x-surrogate-key': 'AkcHu8fRFT7HarTR foo-id_metadata super-test--helix-pages--adobe_head foo-id AkcHu8fRFT7HarTR_metadata G03gAJ9i4zOGySKf',
+        link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
+      });
     });
 
     it('handles error while loading mapped metadata', async () => {

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -748,7 +748,7 @@ describe('Rendering', () => {
       assert.deepStrictEqual(Object.fromEntries(resp.headers.entries()), {
         'access-control-allow-origin': '*',
         'content-type': 'text/html; charset=utf-8',
-        'last-modified': 'Wed, 25 Dec 2024 02:33:33 GMT',
+        'last-modified': 'Wed, 25 Dec 2024 03:33:33 GMT',
         'x-surrogate-key': 'AkcHu8fRFT7HarTR foo-id_metadata super-test--helix-pages--adobe_head foo-id AkcHu8fRFT7HarTR_metadata G03gAJ9i4zOGySKf',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
       });

--- a/test/utils/last-modified.test.js
+++ b/test/utils/last-modified.test.js
@@ -13,7 +13,12 @@
 /* eslint-env mocha */
 
 import assert from 'assert';
-import { extractLastModified, updateLastModified } from '../../src/utils/last-modified.js';
+import {
+  extractLastModified,
+  setLastModified,
+  recordLastModified,
+} from '../../src/utils/last-modified.js';
+import { PipelineResponse } from '../../src/index.js';
 
 describe('Last Modified Utils Test', () => {
   /** @type PipelineState */
@@ -21,42 +26,47 @@ describe('Last Modified Utils Test', () => {
 
   it('sets the last modified if missing', async () => {
     /** @type PipelineResponse */
-    const res = { headers: new Map() };
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 09:33:01 GMT');
+    const res = new PipelineResponse();
+    recordLastModified(state, res, 'source', 'Wed, 12 Jan 2022 09:33:01 GMT');
+    setLastModified(state, res);
     assert.strictEqual(res.headers.get('last-modified'), 'Wed, 12 Jan 2022 09:33:01 GMT');
   });
 
   it('sets the last modified if newer', async () => {
     /** @type PipelineResponse */
-    const res = { headers: new Map() };
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 09:33:01 GMT');
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 14:33:01 GMT');
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 19:33:01 GMT');
+    const res = new PipelineResponse();
+    recordLastModified(state, res, 'source 0', 'Wed, 12 Jan 2022 09:33:01 GMT');
+    recordLastModified(state, res, 'source 1', 'Wed, 12 Jan 2022 14:33:01 GMT');
+    recordLastModified(state, res, 'source 2', 'Wed, 12 Jan 2022 19:33:01 GMT');
+    setLastModified(state, res);
     assert.strictEqual(res.headers.get('last-modified'), 'Wed, 12 Jan 2022 19:33:01 GMT');
   });
 
   it('ignores the last modified if older', async () => {
     /** @type PipelineResponse */
-    const res = { headers: new Map() };
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 09:33:01 GMT');
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 08:33:01 GMT');
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 07:33:01 GMT');
+    const res = new PipelineResponse();
+    recordLastModified(state, res, 'source 0', 'Wed, 12 Jan 2022 09:33:01 GMT');
+    recordLastModified(state, res, 'source 1', 'Wed, 12 Jan 2022 08:33:01 GMT');
+    recordLastModified(state, res, 'source 2', 'Wed, 12 Jan 2022 07:33:01 GMT');
+    setLastModified(state, res);
     assert.strictEqual(res.headers.get('last-modified'), 'Wed, 12 Jan 2022 09:33:01 GMT');
   });
 
   it('ignores invalid last modified', async () => {
     /** @type PipelineResponse */
-    const res = { headers: new Map() };
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 09:33:01 GMT');
-    updateLastModified(state, res, 'Hello, world.');
+    const res = new PipelineResponse();
+    recordLastModified(state, res, 'source 0', 'Wed, 12 Jan 2022 09:33:01 GMT');
+    recordLastModified(state, res, 'source 1', 'Hello, world.');
+    setLastModified(state, res);
     assert.strictEqual(res.headers.get('last-modified'), 'Wed, 12 Jan 2022 09:33:01 GMT');
   });
 
   it('ignores undefined last modified', async () => {
     /** @type PipelineResponse */
-    const res = { headers: new Map() };
-    updateLastModified(state, res, 'Wed, 12 Jan 2022 09:33:01 GMT');
-    updateLastModified(state, res, undefined);
+    const res = new PipelineResponse();
+    recordLastModified(state, res, 'source 0', 'Wed, 12 Jan 2022 09:33:01 GMT');
+    recordLastModified(state, res, 'source 1', undefined);
+    setLastModified(state, res);
     assert.strictEqual(res.headers.get('last-modified'), 'Wed, 12 Jan 2022 09:33:01 GMT');
   });
 


### PR DESCRIPTION
fixes #743

---
I refactored the last-modified handling a bit, so that each source doesn't update the "best" last modified directly, but only adds a record to the `PipelineResponse.lastModifiedSources` object. so when the applied metadata set contains a last-modified, we can change the `metadata` record.

the "best" (i.e. latest) last modified is then calculated before returning the response.


