### PR TITLE
fix: allow json-ld to be sourced from multiple cells

### DIFF
--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -44,7 +44,7 @@ function readBlockConfig($block) {
       const name = toMetaName(toString($name));
       if (name) {
         // special case for json-ld. don't apply any special formatting
-        if (name.toLowerCase() === 'json-ld') {
+        if (name.match(/^json-ld(\\d+)?$/i)) {
           config[name] = toString($value).trim();
           return;
         }

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -65,10 +65,10 @@ export default async function render(state, req, res) {
     appendElement($head, createElement('link', 'rel', 'canonical', 'href', meta.canonical));
   }
 
-  let jsonLd;
+  let jsonLd = '';
   for (const [name, value] of Object.entries(meta.page)) {
-    if (name.toLowerCase() === 'json-ld') {
-      jsonLd = value;
+    if (name.toLowerCase().match(/^json-ld(\\d+)?$/i)) {
+      jsonLd += value;
       // eslint-disable-next-line no-continue
       continue;
     }


### PR DESCRIPTION
Sites that use bulk metadata to add json-ld for individual pages to their site may run into cell size constraints if the snippet grows too large. For example the max cell size limit for Google Sheets is 50k characters. 

In order to allow customers to split the json-ld string into multiple cells we allow for `json-ld`, `json-ld2`, `json-ld3` and so on as metadata keys for pages, and concatenate the values while rendering. 

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
