### PR TITLE
fix: allow canonical URL to end with `index` but not `/index`

### DIFF
--- a/src/steps/utils.js
+++ b/src/steps/utils.js
@@ -54,7 +54,7 @@ export function makeCanonicalHtmlUrl(url) {
   if (base.endsWith('.html')) {
     base = base.substring(0, base.length - 5);
   }
-  if (base.endsWith('index')) {
+  if (base.endsWith('/index')) {
     base = base.substring(0, base.length - 5);
   }
   return `${base}${query}`;

--- a/test/steps/utils.test.js
+++ b/test/steps/utils.test.js
@@ -58,10 +58,12 @@ describe('Make canonical URL', () => {
   it('get correct canonical url', () => {
     assert.strictEqual(makeCanonicalHtmlUrl(null), null);
     assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/'), 'https://spark.adobe.com/');
+    assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/index'), 'https://spark.adobe.com/');
     assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/foo'), 'https://spark.adobe.com/foo');
     assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/foo.html'), 'https://spark.adobe.com/foo');
     assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/foo/index.html'), 'https://spark.adobe.com/foo/');
     assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/foo/index'), 'https://spark.adobe.com/foo/');
+    assert.strictEqual(makeCanonicalHtmlUrl('https://spark.adobe.com/foo-index'), 'https://spark.adobe.com/foo-index');
   });
 
   it('get correct canonical url with query', () => {


### PR DESCRIPTION
Fixes #767

