### PR TITLE
This test passes when it should not? it adds prefix and suffix to wrapped images (with strong or em) but the end up ignored

### DIFF
--- a/test/fixtures/content/images.html
+++ b/test/fixtures/content/images.html
@@ -54,7 +54,25 @@
                 <img loading="lazy" alt=""  src="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
+        <p>image wrapped in em, prefixed and suffixed</p>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt=""  src="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
         <p>image wrapped in strong</p>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt=""  src="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+        <p>image wrapped in strong, prefixed and suffixed</p>
         <p>
             <picture>
                 <source type="image/webp" srcset="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">

--- a/test/fixtures/content/images.md
+++ b/test/fixtures/content/images.md
@@ -22,7 +22,15 @@ image wrapped in em
 
 _![](https://main--pages--adobe.hlx.live/media_ba025e72d401d61d991debe0a2128048fabe0a4f.png)_
 
+image wrapped in em, prefixed and suffixed
+
+_prefix here ![](https://main--pages--adobe.hlx.live/media_ba025e72d401d61d991debe0a2128048fabe0a4f.png) suffix here_
+
+
 image wrapped in strong
 
 **![](https://main--pages--adobe.hlx.live/media_ba025e72d401d61d991debe0a2128048fabe0a4f.png)**
 
+image wrapped in strong, prefixed and suffixed
+
+**prefix here ![](https://main--pages--adobe.hlx.live/media_ba025e72d401d61d991debe0a2128048fabe0a4f.png) suffix here**


### PR DESCRIPTION
In this PR I add tests where images wrapped with `_` or `**` in markdown  have a prefix and suffix text.

I expect the result HTML to contain the prefix and suffix, but the pipeline completely removes the prefix and suffix and the test I added passes when it should fail, is this expected?
