### PR TITLE
fix: only enforce date-check on main

### DIFF
--- a/src/steps/fetch-config.js
+++ b/src/steps/fetch-config.js
@@ -50,10 +50,12 @@ export default async function fetchConfig(state, req, res) {
     });
   }
 
-  // reject new projects
-  const created = new Date(ret.headers.get('x-amz-meta-x-created-date') || '1970-01-01T00:00:00Z');
-  if (created.valueOf() > HELIX5_ENFORCE_DATE) {
-    throw new PipelineStatusError(404, '*.hlx.page projects are not supported after 2025-02-14');
+  // reject new projects (only on main)
+  if (ref === 'main') {
+    const created = new Date(ret.headers.get('x-amz-meta-x-created-date') || '1970-01-01T00:00:00Z');
+    if (created.valueOf() > HELIX5_ENFORCE_DATE) {
+      throw new PipelineStatusError(404, '*.hlx.page projects are not supported after 2025-02-14');
+    }
   }
 
   // set contentbusid from header if missing in config

--- a/test/json-pipe.test.js
+++ b/test/json-pipe.test.js
@@ -592,9 +592,10 @@ describe('JSON Pipe Test', () => {
 
   it('rejects projects create after 14.2.2025', async () => {
     const state = createDefaultState();
+    state.ref = 'main';
     state.s3Loader.reply(
       'helix-code-bus',
-      'owner/repo/ref/helix-config.json',
+      'owner/repo/main/helix-config.json',
       new PipelineResponse(HELIX_CONFIG_JSON_NO_CONTENTBUSID, {
         headers: {
           'x-amz-meta-x-created-date': '2025-02-15T00:00:00Z',


### PR DESCRIPTION
the admin sets the `x-created-date` to *now()* for every new branch on its `helix-config.json`. this would cause new branches to fail even on "old" projects.

