### PR TITLE
feat: Enable CSP with nonce for Helix 5 - 2nd try

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-html-pipeline",
-  "version": "6.17.2",
+  "version": "6.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-html-pipeline",
-      "version": "6.17.2",
+      "version": "6.17.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "7.1.9",
@@ -24,6 +24,7 @@
         "mdast-util-to-string": "4.0.0",
         "micromark-util-subtokenize": "2.0.3",
         "mime": "4.0.4",
+        "parse5-html-rewriting-stream": "7.0.0",
         "rehype-format": "5.0.1",
         "rehype-parse": "9.0.1",
         "remark-parse": "11.0.0",
@@ -10752,6 +10753,20 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-html-rewriting-stream": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-7.0.0.tgz",
+      "integrity": "sha512-mazCyGWkmCRWDI15Zp+UiCqMp/0dgEmkZRvhlsqqKYr4SsVm/TvnSpD9fCvqCA2zoWJcfRym846ejWBBHRiYEg==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.3.0",
+        "parse5": "^7.0.0",
+        "parse5-sax-parser": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
@@ -10773,7 +10788,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-7.0.0.tgz",
       "integrity": "sha512-5A+v2SNsq8T6/mG3ahcz8ZtQ0OUFTatxPbeidoMB7tkJSGDY3tdfl4MHovtLQHkEn5CGxijNWRQHhRQ6IRpXKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mdast-util-to-string": "4.0.0",
         "micromark-util-subtokenize": "2.0.4",
         "mime": "4.0.6",
-        "parse5-html-rewriting-stream": "7.0.0",
+        "parse5": "7.2.1",
         "rehype-format": "5.0.1",
         "rehype-parse": "9.0.1",
         "remark-parse": "11.0.0",
@@ -10783,20 +10783,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-html-rewriting-stream": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-7.0.0.tgz",
-      "integrity": "sha512-mazCyGWkmCRWDI15Zp+UiCqMp/0dgEmkZRvhlsqqKYr4SsVm/TvnSpD9fCvqCA2zoWJcfRym846ejWBBHRiYEg==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.3.0",
-        "parse5": "^7.0.0",
-        "parse5-sax-parser": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
@@ -10818,6 +10804,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-7.0.0.tgz",
       "integrity": "sha512-5A+v2SNsq8T6/mG3ahcz8ZtQ0OUFTatxPbeidoMB7tkJSGDY3tdfl4MHovtLQHkEn5CGxijNWRQHhRQ6IRpXKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mdast-util-to-string": "4.0.0",
     "micromark-util-subtokenize": "2.0.3",
     "mime": "4.0.4",
+    "parse5-html-rewriting-stream": "7.0.0",
     "rehype-format": "5.0.1",
     "rehype-parse": "9.0.1",
     "remark-parse": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mdast-util-to-string": "4.0.0",
     "micromark-util-subtokenize": "2.0.4",
     "mime": "4.0.6",
-    "parse5-html-rewriting-stream": "7.0.0",
+    "parse5": "7.2.1",
     "rehype-format": "5.0.1",
     "rehype-parse": "9.0.1",
     "remark-parse": "11.0.0",

--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -149,6 +149,7 @@ export async function htmlPipe(state, req) {
 
     if (state.content.sourceBus === 'code' || state.info.originalExtension === '.md') {
       state.timer?.update('serialize');
+      await setCustomResponseHeaders(state, req, res);
       await renderCode(state, req, res);
     } else {
       state.timer?.update('parse');
@@ -165,6 +166,7 @@ export async function htmlPipe(state, req) {
       await createPictures(state);
       await extractMetaData(state, req);
       await addHeadingIds(state);
+      await setCustomResponseHeaders(state, req, res);
       await render(state, req, res);
       state.timer?.update('serialize');
       await tohtml(state, req, res);
@@ -172,7 +174,6 @@ export async function htmlPipe(state, req) {
     }
 
     setLastModified(state, res);
-    await setCustomResponseHeaders(state, req, res);
     await setXSurrogateKeyHeader(state, req, res);
   } catch (e) {
     res.error = e.message;

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -90,10 +90,6 @@ function createAndApplyNonceOnAST(res, tree, metaCSP, headersCSP) {
   }
 
   visit(tree, (node) => {
-    if (!['script', 'style', 'link'].includes(node.tagName)) {
-      return;
-    }
-
     if (scriptNonce && node.tagName === 'script' && node.properties?.nonce === 'aem') {
       node.properties.nonce = nonce;
       return;

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -142,7 +142,7 @@ export function contentSecurityPolicyOnAST(res, tree) {
     createAndApplyNonceOnAST(res, tree, metaCSP, headersCSP);
   }
 
-  if (metaCSP?.properties['move-as-header']) {
+  if (metaCSP?.properties['move-as-header'] === 'true') {
     if (!headersCSP) {
       // if we have a CSP in meta but no CSP in headers
       // we can move the CSP from meta to headers, if requested

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import { select } from 'hast-util-select';
+import { Tokenizer } from 'parse5';
 import { remove } from 'unist-util-remove';
-import { RewritingStream } from 'parse5-html-rewriting-stream';
 import { visit } from 'unist-util-visit';
 // eslint-disable-next-line import/no-unresolved
 import cryptoImpl from '#crypto';
@@ -167,47 +167,65 @@ export function contentSecurityPolicyOnCode(state, res) {
   const nonce = createNonce();
   let { scriptNonce, styleNonce } = shouldApplyNonce(null, cspHeader);
 
-  const rewriter = new RewritingStream();
+  const html = res.body;
   const chunks = [];
+  let lastOffset = 0;
 
-  rewriter.on('startTag', (tag, rawHTML) => {
-    if (tag.tagName === 'meta'
-      && tag.attrs.find(
-        (attr) => attr.name.toLowerCase() === 'http-equiv' && attr.value.toLowerCase() === 'content-security-policy',
-      )
-    ) {
-      const contentAttr = tag.attrs.find((attr) => attr.name.toLowerCase() === 'content');
-      if (contentAttr) {
-        ({ scriptNonce, styleNonce } = shouldApplyNonce(contentAttr.value, cspHeader));
+  const getRawHTML = (token) => html.slice(token.location.startOffset, token.location.endOffset);
 
-        if (!cspHeader && tag.attrs.find((attr) => attr.name === 'move-as-header' && attr.value === 'true')) {
-          res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
-          return; // don't push the chunk so it gets removed from the response body
+  const tokenizer = new Tokenizer({
+    sourceCodeLocationInfo: true,
+  }, {
+    onStartTag(tag) {
+      chunks.push(html.slice(lastOffset, tag.location.startOffset));
+      try {
+        if (tag.tagName === 'meta'
+          && tag.attrs.find(
+            (attr) => attr.name.toLowerCase() === 'http-equiv' && attr.value.toLowerCase() === 'content-security-policy',
+          )
+        ) {
+          const contentAttr = tag.attrs.find((attr) => attr.name.toLowerCase() === 'content');
+          if (contentAttr) {
+            ({ scriptNonce, styleNonce } = shouldApplyNonce(contentAttr.value, cspHeader));
+
+            if (!cspHeader && tag.attrs.find((attr) => attr.name === 'move-as-header' && attr.value === 'true')) {
+              res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
+              return; // don't push the chunk so it gets removed from the response body
+            }
+            chunks.push(getRawHTML(tag).replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
+            return;
+          }
         }
-        chunks.push(rawHTML.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
-        return;
+
+        if (scriptNonce && tag.tagName === 'script' && tag.attrs.find((attr) => attr.name === 'nonce' && attr.value === 'aem')) {
+          chunks.push(getRawHTML(tag).replace(/nonce="aem"/i, `nonce="${nonce}"`));
+          return;
+        }
+
+        if (styleNonce && (tag.tagName === 'style' || tag.tagName === 'link') && tag.attrs.find((attr) => attr.name === 'nonce' && attr.value === 'aem')) {
+          chunks.push(getRawHTML(tag).replace(/nonce="aem"/i, `nonce="${nonce}"`));
+          return;
+        }
+
+        chunks.push(getRawHTML(tag));
+      } finally {
+        lastOffset = tag.location.endOffset;
       }
-    }
-
-    if (scriptNonce && tag.tagName === 'script' && tag.attrs.find((attr) => attr.name === 'nonce' && attr.value === 'aem')) {
-      chunks.push(rawHTML.replace(/nonce="aem"/i, `nonce="${nonce}"`));
-      return;
-    }
-
-    if (styleNonce && (tag.tagName === 'style' || tag.tagName === 'link') && tag.attrs.find((attr) => attr.name === 'nonce' && attr.value === 'aem')) {
-      chunks.push(rawHTML.replace(/nonce="aem"/i, `nonce="${nonce}"`));
-      return;
-    }
-
-    chunks.push(rawHTML);
+    },
+    // no-op callbacks. onStartTag will take care of these
+    onComment(_) {},
+    onDoctype(_) {},
+    onEndTag(_) {},
+    onEof(_) {},
+    onCharacter(_) {},
+    onNullCharacter(_) {},
+    onWhitespaceCharacter(_) {},
+    onParseError(_) {},
   });
 
-  rewriter.on('data', (data) => {
-    chunks.push(data);
-  });
+  tokenizer.write(html);
+  chunks.push(html.slice(lastOffset));
 
-  rewriter.write(res.body);
-  rewriter.end();
   res.body = chunks.join('');
   if (cspHeader) {
     res.headers.set('content-security-policy', cspHeader.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import crypto from 'crypto';
+import { select, selectAll } from 'hast-util-select';
+import { remove } from 'unist-util-remove';
+
+export const NONCE_AEM = '\'nonce-aem\'';
+
+function parseCSP(csp) {
+  const parts = csp.split(';');
+  const result = {};
+  parts.forEach((part) => {
+    const [directive, ...values] = part.trim().split(' ');
+    result[directive] = values.join(' ');
+  });
+  return result;
+}
+
+function shouldApplyNonce(csp) {
+  const parsedCSP = parseCSP(csp);
+  return {
+    scriptNonce: parsedCSP['script-src']?.includes(NONCE_AEM),
+    styleNonce: parsedCSP['style-src']?.includes(NONCE_AEM),
+  };
+}
+
+function createAndApplyNonce(res, tree, metaCSP, headersCSP) {
+  const nonce = crypto.randomBytes(16).toString('base64');
+  let scriptNonceResult = false;
+  let styleNonceResult = false;
+
+  if (metaCSP) {
+    const { scriptNonce, styleNonce } = shouldApplyNonce(metaCSP.properties.content);
+    scriptNonceResult ||= scriptNonce;
+    styleNonceResult ||= styleNonce;
+    metaCSP.properties.content = metaCSP.properties.content.replaceAll(NONCE_AEM, `'nonce-${nonce}'`);
+  }
+
+  if (headersCSP) {
+    const { scriptNonce, styleNonce } = shouldApplyNonce(headersCSP);
+    scriptNonceResult ||= scriptNonce;
+    styleNonceResult ||= styleNonce;
+    res.headers.set('content-security-policy', headersCSP.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
+  }
+
+  if (scriptNonceResult) {
+    selectAll('script[nonce="aem"]', tree).forEach((el) => {
+      el.properties.nonce = nonce;
+    });
+  }
+
+  if (styleNonceResult) {
+    selectAll('style[nonce="aem"]', tree).forEach((el) => {
+      el.properties.nonce = nonce;
+    });
+    selectAll('link[rel=stylesheet][nonce="aem"]', tree).forEach((el) => {
+      el.properties.nonce = nonce;
+    });
+  }
+}
+
+export function checkResponseBodyForMetaBasedCSP(res) {
+  return res.body?.includes('http-equiv="content-security-policy"')
+    || res.body?.includes('http-equiv="Content-Security-Policy"');
+}
+
+export function checkResponseBodyForAEMNonce(res) {
+  return res.body?.includes(NONCE_AEM);
+}
+
+export function getMetaCSP(tree) {
+  return select('meta[http-equiv="content-security-policy"]', tree)
+    || select('meta[http-equiv="Content-Security-Policy"]', tree);
+}
+
+export function getHeaderCSP(res) {
+  return res.headers?.get('content-security-policy');
+}
+
+export function contentSecurityPolicy(res, tree) {
+  const metaCSP = getMetaCSP(tree);
+  const headersCSP = getHeaderCSP(res);
+
+  if (!metaCSP && !headersCSP) {
+    // No CSP defined
+    return;
+  }
+
+  // CSP with nonce
+  if (
+    (metaCSP && metaCSP.properties.content.includes(NONCE_AEM))
+    || (headersCSP && headersCSP.includes(NONCE_AEM))
+  ) {
+    createAndApplyNonce(res, tree, metaCSP, headersCSP);
+  }
+
+  if (metaCSP && metaCSP.properties['move-as-header']) {
+    if (!headersCSP) {
+      // if we have a CSP in meta but no CSP in headers
+      // we can move the CSP from meta to headers, if requested
+      res.headers.set('content-security-policy', metaCSP.properties.content);
+      remove(tree, null, metaCSP);
+    } else {
+      delete metaCSP.properties['move-as-header'];
+    }
+  }
+}

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -156,9 +156,10 @@ export function contentSecurityPolicyOnCode(state, res) {
   }
 
   const cspHeader = getHeaderCSP(res);
-  if (!cspHeader?.includes(NONCE_AEM)
-    && !checkResponseBodyForMetaBasedCSP(res)
-    && !checkResponseBodyForAEMNonce(res)) {
+  if (!(
+    cspHeader?.includes(NONCE_AEM)
+    || (checkResponseBodyForMetaBasedCSP(res) && checkResponseBodyForAEMNonce(res))
+  )) {
     return;
   }
 

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -9,11 +9,12 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import crypto from 'crypto';
 import { select } from 'hast-util-select';
 import { remove } from 'unist-util-remove';
 import { RewritingStream } from 'parse5-html-rewriting-stream';
 import { visit } from 'unist-util-visit';
+// eslint-disable-next-line import/no-unresolved
+import cryptoImpl from '#crypto';
 
 export const NONCE_AEM = '\'nonce-aem\'';
 
@@ -58,7 +59,7 @@ function shouldApplyNonce(metaCSPText, headersCSPText) {
  * @returns {string}
  */
 function createNonce() {
-  return crypto.randomBytes(18).toString('base64');
+  return cryptoImpl.randomBytes(18).toString('base64');
 }
 
 /**

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -34,7 +34,7 @@ function shouldApplyNonce(csp) {
 }
 
 function createAndApplyNonce(res, tree, metaCSP, headersCSP) {
-  const nonce = crypto.randomBytes(16).toString('base64');
+  const nonce = crypto.randomBytes(18).toString('base64');
   let scriptNonceResult = false;
   let styleNonceResult = false;
 
@@ -74,6 +74,12 @@ export function checkResponseBodyForMetaBasedCSP(res) {
 }
 
 export function checkResponseBodyForAEMNonce(res) {
+  /*
+    we only look for 'nonce-aem' (single quote) to see if there is a meta CSP with nonce
+    we don't want to generate nonces if they appear just on script/style tags,
+    as those have no effect without the actual CSP meta (or header).
+    this means it is ok to not check for the "nonce-aem" (double quotes)
+   */
   return res.body?.includes(NONCE_AEM);
 }
 

--- a/src/steps/fetch-404.js
+++ b/src/steps/fetch-404.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { extractLastModified, recordLastModified } from '../utils/last-modified.js';
+import { contentSecurityPolicyOnCode } from './csp.js';
 import { getPathKey } from './set-x-surrogate-key-header.js';
 
 /**
@@ -34,6 +35,7 @@ export default async function fetch404(state, req, res) {
 
     // keep 404 response status
     res.body = ret.body;
+    contentSecurityPolicyOnCode(state, res);
     res.headers.set('last-modified', ret.headers.get('last-modified'));
     res.headers.set('content-type', 'text/html; charset=utf-8');
   }

--- a/src/steps/render-code.js
+++ b/src/steps/render-code.js
@@ -10,6 +10,16 @@
  * governing permissions and limitations under the License.
  */
 import mime from 'mime';
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import {
+  contentSecurityPolicy,
+  getHeaderCSP,
+  checkResponseBodyForMetaBasedCSP,
+  NONCE_AEM,
+  checkResponseBodyForAEMNonce,
+} from './csp.js';
+import tohtml from './stringify-response.js';
 
 const CHARSET_RE = /charset=([^()<>@,;:"/[\]?.=\s]*)/i;
 
@@ -32,4 +42,19 @@ export default async function renderCode(state, req, res) {
     }
   }
   res.headers.set('content-type', contentType);
+
+  const cspHeader = getHeaderCSP(res);
+  if (state.type === 'html'
+    && (cspHeader?.includes(NONCE_AEM) || (
+      checkResponseBodyForAEMNonce(res) && checkResponseBodyForMetaBasedCSP(res))
+    )
+  ) {
+    res.document = await unified()
+      .use(rehypeParse)
+      .parse(res.body);
+    res.body = undefined;
+
+    contentSecurityPolicy(res, res.document);
+    await tohtml(state, req, res);
+  }
 }

--- a/src/steps/render-code.js
+++ b/src/steps/render-code.js
@@ -10,16 +10,9 @@
  * governing permissions and limitations under the License.
  */
 import mime from 'mime';
-import { unified } from 'unified';
-import rehypeParse from 'rehype-parse';
 import {
-  contentSecurityPolicy,
-  getHeaderCSP,
-  checkResponseBodyForMetaBasedCSP,
-  NONCE_AEM,
-  checkResponseBodyForAEMNonce,
+  contentSecurityPolicyOnCode,
 } from './csp.js';
-import tohtml from './stringify-response.js';
 
 const CHARSET_RE = /charset=([^()<>@,;:"/[\]?.=\s]*)/i;
 
@@ -43,18 +36,5 @@ export default async function renderCode(state, req, res) {
   }
   res.headers.set('content-type', contentType);
 
-  const cspHeader = getHeaderCSP(res);
-  if (state.type === 'html'
-    && (cspHeader?.includes(NONCE_AEM) || (
-      checkResponseBodyForAEMNonce(res) && checkResponseBodyForMetaBasedCSP(res))
-    )
-  ) {
-    res.document = await unified()
-      .use(rehypeParse)
-      .parse(res.body);
-    res.body = undefined;
-
-    contentSecurityPolicy(res, res.document);
-    await tohtml(state, req, res);
-  }
+  contentSecurityPolicyOnCode(state, res);
 }

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -15,6 +15,7 @@ import { h } from 'hastscript';
 import { unified } from 'unified';
 import rehypeParse from 'rehype-parse';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
+import { contentSecurityPolicy } from './csp.js';
 
 function appendElement($parent, $el) {
   if ($el) {
@@ -102,6 +103,7 @@ export default async function render(state, req, res) {
     const $headHtml = await unified()
       .use(rehypeParse, { fragment: true })
       .parse(headHtml);
+    contentSecurityPolicy(res, $headHtml);
     $head.children.push(...$headHtml.children);
   }
 

--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -15,7 +15,7 @@ import { h } from 'hastscript';
 import { unified } from 'unified';
 import rehypeParse from 'rehype-parse';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
-import { contentSecurityPolicy } from './csp.js';
+import { contentSecurityPolicyOnAST } from './csp.js';
 
 function appendElement($parent, $el) {
   if ($el) {
@@ -103,7 +103,7 @@ export default async function render(state, req, res) {
     const $headHtml = await unified()
       .use(rehypeParse, { fragment: true })
       .parse(headHtml);
-    contentSecurityPolicy(res, $headHtml);
+    contentSecurityPolicyOnAST(res, $headHtml);
     $head.children.push(...$headHtml.children);
   }
 

--- a/test/fixtures/code/super-test/404-csp-nonce.html
+++ b/test/fixtures/code/super-test/404-csp-nonce.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';" move-as-header="true">
+  <title>Page not found</title>
+  <script nonce="aem" type="text/javascript">
+    window.isErrorPage = true;
+    window.errorCode = '404';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Page not found">
+  <script nonce="aem" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script nonce="aem" type="module">
+    window.addEventListener('load', () => {
+      if (document.referrer) {
+        const { origin, pathname } = new URL(document.referrer);
+        if (origin === window.location.origin) {
+          const backBtn = document.createElement('a');
+          backBtn.classList.add('button', 'error-button-back');
+          backBtn.href = pathname;
+          backBtn.textContent = 'Go back';
+          backBtn.title = 'Go back';
+          const btnContainer = document.querySelector('.button-container');
+          btnContainer.append(backBtn);
+        }
+      }
+    });
+  </script>
+  <script nonce="aem" type="module">
+    import { sampleRUM } from '/scripts/aem.js';
+    sampleRUM('404', { source: document.referrer });
+  </script>
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    main.error {
+      min-height: calc(100vh - var(--nav-height));
+      display: flex;
+      align-items: center;
+    }
+
+    main.error .error-number {
+      width: 100%;
+    }
+
+    main.error .error-number text {
+      font-family: monospace;
+    }
+  </style>
+  <link rel="stylesheet" href="/styles/lazy-styles.css">
+</head>
+
+<body>
+  <header></header>
+  <main class="error">
+    <div class="section">
+      <svg viewBox="1 0 38 18" class="error-number">
+        <text x="0" y="17">404</text>
+      </svg>
+      <h2 class="error-message">Page Not Found</h2>
+      <p class="button-container">
+        <a href="/" class="button secondary error-button-home">Go home</a>
+      </p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+
+</html>

--- a/test/fixtures/code/super-test/404-csp-nonce.ref.html
+++ b/test/fixtures/code/super-test/404-csp-nonce.ref.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  
+  <title>Page not found</title>
+  <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" type="text/javascript">
+    window.isErrorPage = true;
+    window.errorCode = '404';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Page not found">
+  <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" type="module">
+    window.addEventListener('load', () => {
+      if (document.referrer) {
+        const { origin, pathname } = new URL(document.referrer);
+        if (origin === window.location.origin) {
+          const backBtn = document.createElement('a');
+          backBtn.classList.add('button', 'error-button-back');
+          backBtn.href = pathname;
+          backBtn.textContent = 'Go back';
+          backBtn.title = 'Go back';
+          const btnContainer = document.querySelector('.button-container');
+          btnContainer.append(backBtn);
+        }
+      }
+    });
+  </script>
+  <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" type="module">
+    import { sampleRUM } from '/scripts/aem.js';
+    sampleRUM('404', { source: document.referrer });
+  </script>
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    main.error {
+      min-height: calc(100vh - var(--nav-height));
+      display: flex;
+      align-items: center;
+    }
+
+    main.error .error-number {
+      width: 100%;
+    }
+
+    main.error .error-number text {
+      font-family: monospace;
+    }
+  </style>
+  <link rel="stylesheet" href="/styles/lazy-styles.css">
+</head>
+
+<body>
+  <header></header>
+  <main class="error">
+    <div class="section">
+      <svg viewBox="1 0 38 18" class="error-number">
+        <text x="0" y="17">404</text>
+      </svg>
+      <h2 class="error-message">Page Not Found</h2>
+      <p class="button-container">
+        <a href="/" class="button secondary error-button-home">Go home</a>
+      </p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+
+</html>

--- a/test/fixtures/code/super-test/static-nonce-fragment.html
+++ b/test/fixtures/code/super-test/static-nonce-fragment.html
@@ -1,0 +1,4 @@
+<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">
+  <SCRIPT nonce="aem" src="/scripts/scripts.js" type="module" ></SCRIPT>
+    <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
+<div>Nonce Test</div>

--- a/test/fixtures/code/super-test/static-nonce-fragment.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-fragment.ref.html
@@ -1,0 +1,4 @@
+<meta http-equiv="content-security-policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
+  <SCRIPT nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module" ></SCRIPT>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+<div>Nonce Test</div>

--- a/test/fixtures/code/super-test/static-nonce-header.html
+++ b/test/fixtures/code/super-test/static-nonce-header.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="aem" src="/scripts/aem.js" type="module"></script>
+    <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="aem" > const a = 1 </script>
+    <style nonce="aem" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="aem" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="aem" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="aem" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="aem" > const a = 2 </script>
+      <style nonce="aem" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-header.ref.html
@@ -14,22 +14,22 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>
 <main>
     <div>
       <h1 id="nonce-test">Nonce Test</h1>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
-      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
-      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>
 <footer></footer>

--- a/test/fixtures/code/super-test/static-nonce-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-header.ref.html
@@ -17,7 +17,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 1 </script>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
@@ -28,7 +28,7 @@
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
       <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 2 </script>
       <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>

--- a/test/fixtures/code/super-test/static-nonce-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-header.ref.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
+      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta-different.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-different.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta-different">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta-different">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>
+    <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="r4nD0m" > const a = 1 </script>
+    <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="r4nD0m" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="r4nD0m" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="r4nD0m" > const a = 2 </script>
+      <style nonce="r4nD0m" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
@@ -18,7 +18,7 @@
     <script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>
     <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
     <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="r4nD0m"> const a = 1 </script>
+    <script nonce="r4nD0m" > const a = 1 </script>
     <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
@@ -29,7 +29,7 @@
       <script nonce="r4nD0m" src="/scripts/aem2.js" type="module"></script>
       <script nonce="r4nD0m" src="/scripts/scripts2.js" type="module"></script>
       <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="r4nD0m"> const a = 2 </script>
+      <script nonce="r4nD0m" > const a = 2 </script>
       <style nonce="r4nD0m" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>

--- a/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta-different">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta-different">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>
+    <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="r4nD0m"> const a = 1 </script>
+    <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="r4nD0m" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="r4nD0m" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="r4nD0m"> const a = 2 </script>
+      <style nonce="r4nD0m" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="aem" src="/scripts/aem.js" type="module"></script>
+    <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="aem" > const a = 1 </script>
+    <style nonce="aem" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="aem" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="aem" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="aem" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="aem" > const a = 2 </script>
+      <style nonce="aem" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
@@ -14,22 +14,22 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>
 <main>
     <div>
       <h1 id="nonce-test">Nonce Test</h1>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
-      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
-      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>
 <footer></footer>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    
     <title>ACME CORP</title>
     <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
     <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
@@ -17,7 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 1 </script>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
@@ -28,7 +29,7 @@
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
       <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 2 </script>
       <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
+      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="aem" src="/scripts/aem.js" type="module"></script>
+    <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="aem" > const a = 1 </script>
+    <style nonce="aem" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="aem" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="aem" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="aem" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="aem" > const a = 2 </script>
+      <style nonce="aem" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.ref.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
     <title>ACME CORP</title>
     <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
     <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
@@ -15,22 +15,22 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>
 <main>
     <div>
       <h1 id="nonce-test">Nonce Test</h1>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
-      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
-      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>
 <footer></footer>

--- a/test/fixtures/code/super-test/static-nonce-meta.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.ref.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+      <h1 id="nonce-test">Nonce Test</h1>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem2.js" type="module"></script>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts2.js" type="module"></script>
+      <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles2.css"/>
+      <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 2 </script>
+      <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style2">body {opacity: 1}</style>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/code/super-test/static-nonce-meta.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.ref.html
@@ -18,7 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 1 </script>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
@@ -29,7 +29,7 @@
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem2.js" type="module"></script>
       <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts2.js" type="module"></script>
       <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles2.css"/>
-      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 2 </script>
+      <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 2 </script>
       <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style2">body {opacity: 1}</style>
     </div>
 </main>

--- a/test/fixtures/content/nonce-headers-different.html
+++ b/test/fixtures/content/nonce-headers-different.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-different">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-different">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>
+    <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="r4nD0m"> const a = 1 </script>
+    <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-headers-different.md
+++ b/test/fixtures/content/nonce-headers-different.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-headers-meta.html
+++ b/test/fixtures/content/nonce-headers-meta.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-headers-meta.html
+++ b/test/fixtures/content/nonce-headers-meta.html
@@ -14,12 +14,12 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/nonce-headers-meta.md
+++ b/test/fixtures/content/nonce-headers-meta.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-headers.html
+++ b/test/fixtures/content/nonce-headers.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-headers">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-headers">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-headers.html
+++ b/test/fixtures/content/nonce-headers.html
@@ -14,11 +14,11 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/nonce-headers.md
+++ b/test/fixtures/content/nonce-headers.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-meta-different.html
+++ b/test/fixtures/content/nonce-meta-different.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta-different">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta-different">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">
+    <script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>
+    <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="r4nD0m"> const a = 1 </script>
+    <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-meta-different.md
+++ b/test/fixtures/content/nonce-meta-different.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-meta-move-as-header.html
+++ b/test/fixtures/content/nonce-meta-move-as-header.html
@@ -14,11 +14,11 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css" />
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css" />
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/nonce-meta-move-as-header.html
+++ b/test/fixtures/content/nonce-meta-move-as-header.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta-move-as-header">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta-move-as-header">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css" />
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-meta-move-as-header.md
+++ b/test/fixtures/content/nonce-meta-move-as-header.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-meta.html
+++ b/test/fixtures/content/nonce-meta.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-meta.html
+++ b/test/fixtures/content/nonce-meta.html
@@ -14,12 +14,12 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css"/>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/nonce-meta.md
+++ b/test/fixtures/content/nonce-meta.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-script-only.html
+++ b/test/fixtures/content/nonce-script-only.html
@@ -14,10 +14,10 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link rel="stylesheet" href="/styles/styles.css" />
-    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
     <style id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-script-only.html
+++ b/test/fixtures/content/nonce-script-only.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-script-only">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-script-only">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/aem.js" type="module"></script>
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ==" src="/scripts/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles/styles.css" />
+    <script nonce="ckFuZDBtbW1yQW5kMG1tbQ=="> const a = 1 </script>
+    <style id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-script-only.md
+++ b/test/fixtures/content/nonce-script-only.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/fixtures/content/nonce-style-only.html
+++ b/test/fixtures/content/nonce-style-only.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>ACME CORP</title>
+    <link rel="canonical" href="https://www.adobe.com/nonce-meta">
+    <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:title" content="ACME CORP">
+    <meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta property="og:url" content="https://www.adobe.com/nonce-meta">
+    <meta property="og:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ACME CORP">
+    <meta name="twitter:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">
+    <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="locale" content="en-US">
+    <meta name="zero-cell" content="0">
+    <script src="/scripts/aem.js" type="module"></script>
+    <script src="/scripts/scripts.js" type="module"></script>
+    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css" />
+    <script> const a = 1 </script>
+    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+</head>
+<body>
+<header></header>
+<main>
+    <div><h1 id="nonce-test">Nonce Test</h1></div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/nonce-style-only.html
+++ b/test/fixtures/content/nonce-style-only.html
@@ -16,9 +16,9 @@
     <meta name="zero-cell" content="0">
     <script src="/scripts/aem.js" type="module"></script>
     <script src="/scripts/scripts.js" type="module"></script>
-    <link nonce="ckFuZDBtbW1yQW5kMG1tbQ==" rel="stylesheet" href="/styles/styles.css" />
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css" />
     <script> const a = 1 </script>
-    <style nonce="ckFuZDBtbW1yQW5kMG1tbQ==" id="at-body-style">body {opacity: 1}</style>
+    <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>
 <header></header>

--- a/test/fixtures/content/nonce-style-only.md
+++ b/test/fixtures/content/nonce-style-only.md
@@ -1,0 +1,1 @@
+# Nonce Test

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -187,13 +187,14 @@ describe('Rendering', () => {
     } catch {
       // ignore
     }
-    console.log(expHtml);
+    // console.log(expHtml);
     if (!expStatus) {
       // eslint-disable-next-line no-param-reassign
       expStatus = expHtml === null ? 404 : 200;
     }
     const response = await render(url, '', expStatus, partition);
     const actHtml = response.body;
+    // console.log(actHtml);
     if (expStatus === 200) {
       const $actMain = new JSDOM(actHtml).window.document.querySelector(domSelector);
       const $expMain = new JSDOM(expHtml).window.document.querySelector(domSelector);
@@ -542,7 +543,7 @@ describe('Rendering', () => {
     it('renders csp nonce meta', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           head: {
@@ -565,7 +566,7 @@ describe('Rendering', () => {
     it('renders csp nonce headers', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -587,7 +588,7 @@ describe('Rendering', () => {
         };
         const { headers } = await testRender('nonce-headers', 'html');
         // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
         crypto.randomBytes = originalRandomBytes;
       }
@@ -596,7 +597,7 @@ describe('Rendering', () => {
     it('renders csp nonce metadata - move as header', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           head: {
@@ -605,13 +606,13 @@ describe('Rendering', () => {
               + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
               + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
               + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<script nonce="aem"> const a = 1 </script>\n'
               + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
           },
         };
         const { headers } = await testRender('nonce-meta-move-as-header', 'html');
         // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
         crypto.randomBytes = originalRandomBytes;
       }
@@ -620,7 +621,7 @@ describe('Rendering', () => {
     it('renders csp nonce headers and metadata - move as header', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -651,7 +652,7 @@ describe('Rendering', () => {
     it('renders csp nonce script only', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -667,20 +668,20 @@ describe('Rendering', () => {
             html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
               + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
               + '<link rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<script nonce="aem"> const a = 1 </script>\n'
               + '<style id="at-body-style">body {opacity: 1}</style>',
           },
         };
         const { headers } = await testRender('nonce-script-only', 'html');
         // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
       } finally {
         crypto.randomBytes = originalRandomBytes;
       }
     });
 
     it('does not alter csp nonce if already set to a different value by meta', async () => {
-      crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+      crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
       config = {
         ...DEFAULT_CONFIG,
         head: {
@@ -698,7 +699,7 @@ describe('Rendering', () => {
     });
 
     it('does not alter csp nonce if already set to a different value by header', async () => {
-      crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+      crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
       config = {
         ...DEFAULT_CONFIG,
         headers: {
@@ -1010,7 +1011,7 @@ describe('Rendering', () => {
     it('renders static html from the codebus and applies csp from header with nonce', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -1026,7 +1027,7 @@ describe('Rendering', () => {
 
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-header.html'));
         // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
         crypto.randomBytes = originalRandomBytes;
       }
@@ -1035,7 +1036,7 @@ describe('Rendering', () => {
     it('renders static html from the codebus and applies csp from meta with nonce', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta.html'));
         assert.ok(!headers.get('content-security-policy'));
       } finally {
@@ -1046,10 +1047,10 @@ describe('Rendering', () => {
     it('renders static html from the codebus and applies csp from meta with nonce moved as header', async () => {
       const originalRandomBytes = crypto.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
         // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
         crypto.randomBytes = originalRandomBytes;
       }

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -11,6 +11,7 @@
  */
 /* eslint-env mocha */
 import assert from 'assert';
+import crypto from 'crypto';
 import path from 'path';
 import { readFile } from 'fs/promises';
 import { JSDOM } from 'jsdom';
@@ -186,13 +187,13 @@ describe('Rendering', () => {
     } catch {
       // ignore
     }
+    console.log(expHtml);
     if (!expStatus) {
       // eslint-disable-next-line no-param-reassign
       expStatus = expHtml === null ? 404 : 200;
     }
     const response = await render(url, '', expStatus, partition);
     const actHtml = response.body;
-    console.log(actHtml);
     if (expStatus === 200) {
       const $actMain = new JSDOM(actHtml).window.document.querySelector(domSelector);
       const $expMain = new JSDOM(expHtml).window.document.querySelector(domSelector);
@@ -217,6 +218,31 @@ describe('Rendering', () => {
     const $actMain = new JSDOM(actHtml).window.document.querySelector('body');
     const $expMain = new JSDOM(expHtml).window.document.querySelector('body');
     await assertHTMLEquals($actMain.outerHTML, $expMain.outerHTML);
+    return response;
+  }
+
+  async function testRenderCode(url, expStatus = 200) {
+    if (!(url instanceof URL)) {
+      // eslint-disable-next-line no-param-reassign
+      url = new URL(`https://helix-pages.com/${url}`);
+    }
+    const spec = url.pathname.split('/').pop().split('.')[0];
+    const expFile = path.resolve(__testdir, 'fixtures', 'code/super-test', `${spec}.ref.html`);
+    let expHtml = null;
+    try {
+      expHtml = await readFile(expFile, 'utf-8');
+    } catch {
+      // ignore
+    }
+
+    const response = await render(url);
+    assert.strictEqual(response.status, expStatus);
+    const actHtml = response.body;
+    if (expStatus === 200) {
+      const $actMain = new JSDOM(actHtml).window.document.querySelector('html');
+      const $expMain = new JSDOM(expHtml).window.document.querySelector('html');
+      await assertHTMLEquals($actMain.outerHTML, $expMain.outerHTML);
+    }
     return response;
   }
 
@@ -513,6 +539,190 @@ describe('Rendering', () => {
       await testRender('head-with-script', 'html');
     });
 
+    it('renders csp nonce meta', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          head: {
+            // eslint-disable-next-line quotes
+            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">\n`
+              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+          },
+        };
+        const { headers } = await testRender('nonce-meta', 'html');
+        assert.ok(!headers.get('content-security-policy'));
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders csp nonce headers', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          headers: {
+            '/**': [
+              {
+                key: 'Content-Security-Policy',
+                // eslint-disable-next-line quotes
+                value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
+              },
+            ],
+          },
+          head: {
+            html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+          },
+        };
+        const { headers } = await testRender('nonce-headers', 'html');
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders csp nonce metadata - move as header', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          head: {
+            // eslint-disable-next-line quotes
+            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true" />\n`
+              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+          },
+        };
+        const { headers } = await testRender('nonce-meta-move-as-header', 'html');
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders csp nonce headers and metadata - move as header', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          headers: {
+            '/**': [
+              {
+                key: 'content-security-policy',
+                value: 'frame-ancestors \'self\'',
+              },
+            ],
+          },
+          head: {
+            // eslint-disable-next-line quotes
+            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">\n`
+              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+          },
+        };
+        const { headers } = await testRender('nonce-headers-meta', 'html');
+        assert.strictEqual(headers.get('content-security-policy'), 'frame-ancestors \'self\'');
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders csp nonce script only', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          headers: {
+            '/**': [
+              {
+                key: 'content-security-policy',
+                // eslint-disable-next-line quotes
+                value: `script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';`,
+              },
+            ],
+          },
+          head: {
+            html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+              + '<link rel="stylesheet" href="/styles/styles.css"/>\n'
+              + '<script nonce="aem" > const a = 1 </script>\n'
+              + '<style id="at-body-style">body {opacity: 1}</style>',
+          },
+        };
+        const { headers } = await testRender('nonce-script-only', 'html');
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('does not alter csp nonce if already set to a different value by meta', async () => {
+      crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        head: {
+          // eslint-disable-next-line quotes
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">\n`
+            + '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-meta-different', 'html');
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('does not alter csp nonce if already set to a different value by header', async () => {
+      crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'Content-Security-Policy',
+              // eslint-disable-next-line quotes
+              value: `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`,
+            },
+          ],
+        },
+        head: {
+          html: '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-headers-different', 'html');
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`);
+    });
+
     it('renders 404 if content not found', async () => {
       await testRender('not-found', 'html');
       // preview (code coverage)
@@ -795,6 +1005,59 @@ describe('Rendering', () => {
         'x-surrogate-key': 'OhRDjcpvIRqjAeih super-test--helix-pages--adobe_code',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
       });
+    });
+
+    it('renders static html from the codebus and applies csp from header with nonce', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        config = {
+          ...DEFAULT_CONFIG,
+          headers: {
+            '/**': [
+              {
+                key: 'content-security-policy',
+                // eslint-disable-next-line quotes
+                value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
+              },
+            ],
+          },
+        };
+
+        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-header.html'));
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders static html from the codebus and applies csp from meta with nonce', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta.html'));
+        assert.ok(!headers.get('content-security-policy'));
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders static html from the codebus and applies csp from meta with nonce moved as header', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rAnd0mmmrAnd0mmm');
+        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ==' 'strict-dynamic'; style-src 'nonce-ckFuZDBtbW1yQW5kMG1tbQ=='; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders static html from the codebus and applies csp with different nonce without altering', async () => {
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-different.html'));
+      assert.ok(!headers.get('content-security-policy'));
     });
   });
 });

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -222,12 +222,14 @@ describe('Rendering', () => {
     return response;
   }
 
-  async function testRenderCode(url, expStatus = 200) {
+  async function testRenderCode(url, expStatus = 200, spec = null, forceCompare = false) {
     if (!(url instanceof URL)) {
       // eslint-disable-next-line no-param-reassign
       url = new URL(`https://helix-pages.com/${url}`);
     }
-    const spec = url.pathname.split('/').pop().split('.')[0];
+
+    // eslint-disable-next-line no-param-reassign
+    spec = spec || url.pathname.split('/').pop().split('.')[0];
     const expFile = path.resolve(__testdir, 'fixtures', 'code/super-test', `${spec}.ref.html`);
     let expHtml = null;
     try {
@@ -236,13 +238,16 @@ describe('Rendering', () => {
       // ignore
     }
 
-    const response = await render(url);
+    const response = await render(url, '', expStatus);
     assert.strictEqual(response.status, expStatus);
     const actHtml = response.body;
-    if (expStatus === 200) {
-      const $actMain = new JSDOM(actHtml).window.document.querySelector('html');
-      const $expMain = new JSDOM(expHtml).window.document.querySelector('html');
-      await assertHTMLEquals($actMain.outerHTML, $expMain.outerHTML);
+    // console.log(actHtml);
+    if (expStatus === 200 || forceCompare) {
+      /*
+       we use strict equality here because we want to ensure minimal intrusion in the customer HTML
+       by the rendering pipeline. JSDOM will normalize the HTML, so we can't use it for comparison.
+      */
+      assert.strictEqual(actHtml, expHtml);
     }
     return response;
   }
@@ -1059,6 +1064,32 @@ describe('Rendering', () => {
     it('renders static html from the codebus and applies csp with different nonce without altering', async () => {
       const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-different.html'));
       assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('renders static html from the codebus and applies csp without altering the HTML structure', async () => {
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-fragment.html'));
+        assert.ok(!headers.get('content-security-policy'));
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('renders 404 html from codebus and applies csp', async () => {
+      loader
+        .rewrite('404.html', 'super-test/404-csp-nonce.html')
+        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
+      const originalRandomBytes = crypto.randomBytes;
+      try {
+        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        const { headers } = await testRenderCode('not-found', 404, '404-csp-nonce', true);
+        // eslint-disable-next-line quotes
+        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
+      } finally {
+        crypto.randomBytes = originalRandomBytes;
+      }
     });
   });
 });

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -11,7 +11,6 @@
  */
 /* eslint-env mocha */
 import assert from 'assert';
-import crypto from 'crypto';
 import path from 'path';
 import { readFile } from 'fs/promises';
 import { JSDOM } from 'jsdom';
@@ -19,6 +18,8 @@ import { assertHTMLEquals } from './utils.js';
 
 import { htmlPipe, PipelineRequest, PipelineState } from '../src/index.js';
 import { FileS3Loader } from './FileS3Loader.js';
+// eslint-disable-next-line import/no-unresolved
+import cryptoImpl from '#crypto';
 
 const METADATA = {
   data: {
@@ -546,9 +547,9 @@ describe('Rendering', () => {
     });
 
     it('renders csp nonce meta', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           head: {
@@ -564,14 +565,14 @@ describe('Rendering', () => {
         const { headers } = await testRender('nonce-meta', 'html');
         assert.ok(!headers.get('content-security-policy'));
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders csp nonce headers', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -595,14 +596,14 @@ describe('Rendering', () => {
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders csp nonce metadata - move as header', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           head: {
@@ -619,14 +620,14 @@ describe('Rendering', () => {
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders csp nonce headers and metadata - move as header', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -650,14 +651,14 @@ describe('Rendering', () => {
         const { headers } = await testRender('nonce-headers-meta', 'html');
         assert.strictEqual(headers.get('content-security-policy'), 'frame-ancestors \'self\'');
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders csp nonce script only', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -681,12 +682,12 @@ describe('Rendering', () => {
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('does not alter csp nonce if already set to a different value by meta', async () => {
-      crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
       config = {
         ...DEFAULT_CONFIG,
         head: {
@@ -704,7 +705,7 @@ describe('Rendering', () => {
     });
 
     it('does not alter csp nonce if already set to a different value by header', async () => {
-      crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
       config = {
         ...DEFAULT_CONFIG,
         headers: {
@@ -1026,9 +1027,9 @@ describe('Rendering', () => {
     });
 
     it('renders static html from the codebus and applies csp from header with nonce', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         config = {
           ...DEFAULT_CONFIG,
           headers: {
@@ -1046,30 +1047,30 @@ describe('Rendering', () => {
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders static html from the codebus and applies csp from meta with nonce', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta.html'));
         assert.ok(!headers.get('content-security-policy'));
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
     it('renders static html from the codebus and applies csp from meta with nonce moved as header', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
@@ -1079,13 +1080,13 @@ describe('Rendering', () => {
     });
 
     it('renders static html from the codebus and applies csp without altering the HTML structure', async () => {
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-fragment.html'));
         assert.ok(!headers.get('content-security-policy'));
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
 
@@ -1093,14 +1094,14 @@ describe('Rendering', () => {
       loader
         .rewrite('404.html', 'super-test/404-csp-nonce.html')
         .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
-      const originalRandomBytes = crypto.randomBytes;
+      const originalRandomBytes = cryptoImpl.randomBytes;
       try {
-        crypto.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
         const { headers } = await testRenderCode('not-found', 404, '404-csp-nonce', true);
         // eslint-disable-next-line quotes
         assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
       } finally {
-        crypto.randomBytes = originalRandomBytes;
+        cryptoImpl.randomBytes = originalRandomBytes;
       }
     });
   });


### PR DESCRIPTION
## 1. Description
1. Allow customers to define a nonce based CSP using either a meta tag or header, with cached nonce, with the keyword `'nonce-aem'`.

**Meta:**
```html
    <meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic';  base-uri 'self'; objectsrc 'none';">
```
**Header**
```
content-security-policy: script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';
```
3. Developers need to also add `nonce="aem"` on:
*  each script from `head.html`
*  each script from static html files in github

Example:
``` html
<script nonce="aem" src="/scripts/aem.js" type="module"></script>
<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
```

4. Add support for a `move-as-header` attribute for the meta based CSP, where the Helix Pipeline will that tag as a header 

_Note: if this feature is premature, I can remove it and file it as a separate PR_

Example:
```html
<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';" move-as-header="true">
```

5. The pipeline will generate a 16byte base64 encoded nonce, place it the `aem` part of the `nonce-aem` CSP and on each trusted script where it finds `nonce="aem"`

## 2. Implementation choice
After some back and forth between:
* having `'nonce'` vs `'nonce-aem'` as a keyword in the CSP
* requiring developers to add `'nonce="aem"` or not to the scripts, to make it as friction-less and transparent as possible for devs.

I chose for the moment `'nonce-aem'` and needing to add `'nonce="aem"` to the scripts, because in this implementation if there's any reason to deactivate/remove or if the hlx pipeline fails to render the nonce, customers that have this enabled will still have a valid page that is rendered by the browser.
In the other variants, if for any reason `'nonce'` is returned the browser will show just a white page.

### 3. Expected level of protection with a nonce cached on the CDN

**1. Protected even if the nonce is cached**

✅  `.innerHTML` for XSS
✅  `.outerHTML` for XSS
✅  `.insertAdjecentHTML` for XSS
✅  `.setHTMLUnsafe` for XSS
✅  `eval` / `setTimeout` / `setInterval` / Function for XSS
✅  `javascript:` protocol in the href/src attributes
✅  `location.href` / `location.assign()` / `location.replace` for XSS
✅  attribute event handlers (`onclick`, `onblur`, `onload`, `onerror` etc.) for XSS
✅  stored/reflected XSS
* as long as there is no server side manipulation of the HTML in the customer's CDN where user input is involved
* as long as the nonce is regenerated for requests that hit the origin
* for meta tag: as long as the XSS doesn't happen before the meta tag

**2. not protected, because the nonce is cached**

❌  `document.write` / `document.writeln` -> because you could get the nonce and use it in the exploit

**3.not protected for other reasons**

❌  `document.createRange().createContextualFragment` -> whether the nonce is cached/known is irrelevant, scripts are always executed with `strict-dynamic`. (needs ticket in https://github.com/w3c/webappsec-csp - awaiting OSS approval)
❌  `src` attribute of a `<script>` tag created by `document.createElement('script')` /  text content of a `<script>` tag created by `document.createElement('script')` / `import` -> permitted by `strict-dynamic`

**4. not protected by CSPs in general**
Script-less attacks
❌  HTML injection
❌ DOM clobbering

**5. unknown status**
❓ `element.style` or `cssText` -> still researching, can’t find a working exploit even without CSP

### 4. Still TODO
- [x] Backport to helix 4 in the `5.x` branch.
- [x] Validate that pages render correctly E2E in the helix 4 branch (helix5 doesn't support - `hlx-pipeline-version`)
- [x] Add support in the aem cli for nonce on the live-reload script