### PR TITLE
fix: Use Web Crypto compatible function for nonce generation - v1

### DIFF
--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -59,7 +59,9 @@ function shouldApplyNonce(metaCSPText, headersCSPText) {
  * @returns {string}
  */
 function createNonce() {
-  return cryptoImpl.randomBytes(18).toString('base64');
+  const array = new Uint8Array(18);
+  cryptoImpl.getRandomValues(array);
+  return btoa(String.fromCharCode(...array));
 }
 
 /**


### PR DESCRIPTION
Currently trying to serve a page with nonce CSP results in `500` in cloudflare:
`Worker: x-error: crypto_worker_default2.randomBytes is not a function`

```bash
curl ${CLOUDFLARE_ENDPOINT}/preview/adobe/helix-labs-website/csp-nonce/

< HTTP/2 200 
< date: Thu, 13 Feb 2025 00:28:48 GMT
< content-type: text/html; charset=utf-8
< content-length: 12006
< last-modified: Thu, 13 Feb 2025 00:16:47 GMT
< content-security-policy: script-src 'nonce-MEp9pOJCGw6/rtKRGuKzuLKU' 'strict-dynamic'; base-uri 'self'; object-src 'none';
...
<!DOCTYPE html>
<html>
  <head>
    <title>Home | Admin Labs</title>
    ...
    <script nonce="MEp9pOJCGw6/rtKRGuKzuLKU" src="/scripts/aem.js" type="module"></script>
    <script nonce="MEp9pOJCGw6/rtKRGuKzuLKU" src="/scripts/scripts.js" type="module"></script>
    <link rel="stylesheet" href="/styles/styles.css">
  </head>
  <body>
  </body>
</html>
```