### PR TITLE
fix: Use Web Crypto compatible function for nonce generation - v2

### DIFF
--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -496,6 +496,233 @@ describe('Rendering', () => {
     });
   });
 
+  describe('csp', () => {
+    const originalRandomUUID = cryptoImpl.randomUUID;
+    const uuids = [
+      '7241346e-6430-6d6d-6d72-41346e64306d',
+      '6d6d0000-0000-0000-0000-000000000000',
+    ];
+    let uuidIdx = 0;
+
+    beforeEach(() => {
+      uuidIdx = 0;
+      // eslint-disable-next-line no-plusplus
+      cryptoImpl.randomUUID = () => uuids[uuidIdx++];
+    });
+
+    afterEach(() => {
+      cryptoImpl.randomUUID = originalRandomUUID;
+    });
+
+    it('renders csp nonce meta', async () => {
+      config = {
+        ...DEFAULT_CONFIG,
+        head: {
+          // eslint-disable-next-line quotes
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">\n`
+            + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-meta', 'html');
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('renders csp nonce headers', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'Content-Security-Policy',
+              // eslint-disable-next-line quotes
+              value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
+            },
+          ],
+        },
+        head: {
+          html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-headers', 'html');
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('renders csp nonce metadata - move as header', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        head: {
+          // eslint-disable-next-line quotes
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true" />\n`
+            + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="aem"> const a = 1 </script>\n'
+            + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-meta-move-as-header', 'html');
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('renders csp nonce headers and metadata - move as header', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'content-security-policy',
+              value: 'frame-ancestors \'self\'',
+            },
+          ],
+        },
+        head: {
+          // eslint-disable-next-line quotes
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">\n`
+            + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-headers-meta', 'html');
+      assert.strictEqual(headers.get('content-security-policy'), 'frame-ancestors \'self\'');
+    });
+
+    it('renders csp nonce script only', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'content-security-policy',
+              // eslint-disable-next-line quotes
+              value: `script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';`,
+            },
+          ],
+        },
+        head: {
+          html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="aem"> const a = 1 </script>\n'
+            + '<style id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-script-only', 'html');
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('does not alter csp nonce if already set to a different value by meta', async () => {
+      config = {
+        ...DEFAULT_CONFIG,
+        head: {
+          // eslint-disable-next-line quotes
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">\n`
+            + '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-meta-different', 'html');
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('does not alter csp nonce if already set to a different value by header', async () => {
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'Content-Security-Policy',
+              // eslint-disable-next-line quotes
+              value: `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`,
+            },
+          ],
+        },
+        head: {
+          html: '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
+            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
+            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
+            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
+        },
+      };
+      const { headers } = await testRender('nonce-headers-different', 'html');
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('renders static html from the codebus and applies csp from header with nonce', async () => {
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'content-security-policy',
+              // eslint-disable-next-line quotes
+              value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
+            },
+          ],
+        },
+      };
+
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-header.html'));
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('renders static html from the codebus and applies csp from meta with nonce', async () => {
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta.html'));
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('renders static html from the codebus and applies csp from meta with nonce moved as header', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('renders static html from the codebus and applies csp with different nonce without altering', async () => {
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-different.html'));
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('renders static html from the codebus and applies csp without altering the HTML structure', async () => {
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-fragment.html'));
+      assert.ok(!headers.get('content-security-policy'));
+    });
+
+    it('renders 404 html from codebus and applies csp', async () => {
+      loader
+        .rewrite('404.html', 'super-test/404-csp-nonce.html')
+        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
+      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
+      const { headers } = await testRenderCode('not-found', 404, '404-csp-nonce', true);
+      // eslint-disable-next-line quotes
+      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
+    });
+  });
+
   describe('Miscellaneous', () => {
     it('sets the surrogate-keys correctly', async () => {
       const resp = await testRender('page-block-empty-cols');
@@ -544,190 +771,6 @@ describe('Rendering', () => {
         },
       };
       await testRender('head-with-script', 'html');
-    });
-
-    it('renders csp nonce meta', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          head: {
-            // eslint-disable-next-line quotes
-            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">\n`
-              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
-              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
-              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem" > const a = 1 </script>\n'
-              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
-          },
-        };
-        const { headers } = await testRender('nonce-meta', 'html');
-        assert.ok(!headers.get('content-security-policy'));
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders csp nonce headers', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          headers: {
-            '/**': [
-              {
-                key: 'Content-Security-Policy',
-                // eslint-disable-next-line quotes
-                value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
-              },
-            ],
-          },
-          head: {
-            html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
-              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
-              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem" > const a = 1 </script>\n'
-              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
-          },
-        };
-        const { headers } = await testRender('nonce-headers', 'html');
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders csp nonce metadata - move as header', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          head: {
-            // eslint-disable-next-line quotes
-            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true" />\n`
-              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
-              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
-              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem"> const a = 1 </script>\n'
-              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
-          },
-        };
-        const { headers } = await testRender('nonce-meta-move-as-header', 'html');
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders csp nonce headers and metadata - move as header', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          headers: {
-            '/**': [
-              {
-                key: 'content-security-policy',
-                value: 'frame-ancestors \'self\'',
-              },
-            ],
-          },
-          head: {
-            // eslint-disable-next-line quotes
-            html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">\n`
-              + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
-              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
-              + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem" > const a = 1 </script>\n'
-              + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
-          },
-        };
-        const { headers } = await testRender('nonce-headers-meta', 'html');
-        assert.strictEqual(headers.get('content-security-policy'), 'frame-ancestors \'self\'');
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders csp nonce script only', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          headers: {
-            '/**': [
-              {
-                key: 'content-security-policy',
-                // eslint-disable-next-line quotes
-                value: `script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';`,
-              },
-            ],
-          },
-          head: {
-            html: '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
-              + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
-              + '<link rel="stylesheet" href="/styles/styles.css"/>\n'
-              + '<script nonce="aem"> const a = 1 </script>\n'
-              + '<style id="at-body-style">body {opacity: 1}</style>',
-          },
-        };
-        const { headers } = await testRender('nonce-script-only', 'html');
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('does not alter csp nonce if already set to a different value by meta', async () => {
-      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-      config = {
-        ...DEFAULT_CONFIG,
-        head: {
-          // eslint-disable-next-line quotes
-          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';">\n`
-            + '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
-            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
-            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
-            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
-            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
-        },
-      };
-      const { headers } = await testRender('nonce-meta-different', 'html');
-      assert.ok(!headers.get('content-security-policy'));
-    });
-
-    it('does not alter csp nonce if already set to a different value by header', async () => {
-      cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-      config = {
-        ...DEFAULT_CONFIG,
-        headers: {
-          '/**': [
-            {
-              key: 'Content-Security-Policy',
-              // eslint-disable-next-line quotes
-              value: `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`,
-            },
-          ],
-        },
-        head: {
-          html: '<script nonce="r4nD0m" src="/scripts/aem.js" type="module"></script>\n'
-            + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
-            + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
-            + '<script nonce="r4nD0m" > const a = 1 </script>\n'
-            + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
-        },
-      };
-      const { headers } = await testRender('nonce-headers-different', 'html');
-      // eslint-disable-next-line quotes
-      assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-r4nD0m' 'strict-dynamic'; style-src 'nonce-r4nD0m'; base-uri 'self'; object-src 'none';`);
     });
 
     it('renders 404 if content not found', async () => {
@@ -1024,85 +1067,6 @@ describe('Rendering', () => {
         'x-surrogate-key': 'OhRDjcpvIRqjAeih super-test--helix-pages--adobe_code',
         link: '</scripts/scripts.js>; rel=modulepreload; as=script; crossorigin=use-credentials',
       });
-    });
-
-    it('renders static html from the codebus and applies csp from header with nonce', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        config = {
-          ...DEFAULT_CONFIG,
-          headers: {
-            '/**': [
-              {
-                key: 'content-security-policy',
-                // eslint-disable-next-line quotes
-                value: `script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';`,
-              },
-            ],
-          },
-        };
-
-        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-header.html'));
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders static html from the codebus and applies csp from meta with nonce', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta.html'));
-        assert.ok(!headers.get('content-security-policy'));
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders static html from the codebus and applies csp from meta with nonce moved as header', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders static html from the codebus and applies csp with different nonce without altering', async () => {
-      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-different.html'));
-      assert.ok(!headers.get('content-security-policy'));
-    });
-
-    it('renders static html from the codebus and applies csp without altering the HTML structure', async () => {
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-fragment.html'));
-        assert.ok(!headers.get('content-security-policy'));
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
-    });
-
-    it('renders 404 html from codebus and applies csp', async () => {
-      loader
-        .rewrite('404.html', 'super-test/404-csp-nonce.html')
-        .headers('super-test/404-test.html', 'x-amz-meta-x-source-last-modified', 'Mon, 12 Oct 2009 17:50:00 GMT');
-      const originalRandomBytes = cryptoImpl.randomBytes;
-      try {
-        cryptoImpl.randomBytes = () => Buffer.from('rA4nd0mmmrA4nd0mmm');
-        const { headers } = await testRenderCode('not-found', 404, '404-csp-nonce', true);
-        // eslint-disable-next-line quotes
-        assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; base-uri 'self'; object-src 'none';`);
-      } finally {
-        cryptoImpl.randomBytes = originalRandomBytes;
-      }
     });
   });
 });


### PR DESCRIPTION
Currently trying to serve a page with nonce CSP results in `500` in cloudflare:
`Worker: x-error: crypto_worker_default2.randomBytes is not a function`

Deployed the fix and tested in Cloudflare:
```bash
curl ${CLOUFLARE_CI_ENDPOINT}/preview/adobe/helix-labs-website/csp-nonce/  -v

< HTTP/2 200 
< date: Thu, 13 Feb 2025 00:16:57 GMT
< content-type: text/html; charset=utf-8
< content-length: 12006
< last-modified: Thu, 13 Feb 2025 00:16:47 GMT
< content-security-policy: script-src 'nonce-avl5oxNCQ0axF7vcbunZIkl1' 'strict-dynamic'; base-uri 'self'; object-src 'none';
...
<!DOCTYPE html>
<html>
  <head>
    <title>Home | Admin Labs</title>
    ...
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <script nonce="avl5oxNCQ0axF7vcbunZIkl1" src="/scripts/aem.js" type="module"></script>
    <script nonce="avl5oxNCQ0axF7vcbunZIkl1" src="/scripts/scripts.js" type="module"></script>
    ...
  </head>
  <body>
    ...
  </body>
</html>
```