### PR TITLE
wip: feat: Add script nonce to <link as=script>

### DIFF
--- a/test/fixtures/code/super-test/static-nonce-fragment.html
+++ b/test/fixtures/code/super-test/static-nonce-fragment.html
@@ -1,4 +1,5 @@
 <meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';">
   <SCRIPT nonce="aem" src="/scripts/scripts.js" type="module" ></SCRIPT>
     <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
+    <link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>
 <div>Nonce Test</div>

--- a/test/fixtures/code/super-test/static-nonce-fragment.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-fragment.ref.html
@@ -1,4 +1,5 @@
 <meta http-equiv="content-security-policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
   <SCRIPT nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module" ></SCRIPT>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
 <div>Nonce Test</div>

--- a/test/fixtures/code/super-test/static-nonce-header.html
+++ b/test/fixtures/code/super-test/static-nonce-header.html
@@ -18,6 +18,7 @@
     <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
     <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="aem" > const a = 1 </script>
+    <link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="aem" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-header.ref.html
@@ -18,6 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-meta-different.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-different.html
@@ -19,6 +19,7 @@
     <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
     <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="r4nD0m" > const a = 1 </script>
+    <link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-different.ref.html
@@ -19,6 +19,7 @@
     <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
     <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="r4nD0m" > const a = 1 </script>
+    <link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
@@ -19,6 +19,7 @@
     <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
     <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="aem" > const a = 1 </script>
+    <link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="aem" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.ref.html
@@ -19,6 +19,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" > const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/code/super-test/static-nonce-meta.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.html
@@ -15,6 +15,7 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
+    <link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>
     <script nonce="aem" src="/scripts/aem.js" type="module"></script>
     <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
     <link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>

--- a/test/fixtures/code/super-test/static-nonce-meta.ref.html
+++ b/test/fixtures/code/super-test/static-nonce-meta.ref.html
@@ -15,6 +15,7 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>

--- a/test/fixtures/content/nonce-headers-different.html
+++ b/test/fixtures/content/nonce-headers-different.html
@@ -18,6 +18,7 @@
     <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
     <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="r4nD0m"> const a = 1 </script>
+    <link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-headers-meta.html
+++ b/test/fixtures/content/nonce-headers-meta.html
@@ -19,6 +19,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-headers.html
+++ b/test/fixtures/content/nonce-headers.html
@@ -18,6 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-meta-different.html
+++ b/test/fixtures/content/nonce-meta-different.html
@@ -19,6 +19,7 @@
     <script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>
     <link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="r4nD0m"> const a = 1 </script>
+    <link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-meta-move-as-header.html
+++ b/test/fixtures/content/nonce-meta-move-as-header.html
@@ -18,6 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css" />
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-meta.html
+++ b/test/fixtures/content/nonce-meta.html
@@ -19,6 +19,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="stylesheet" href="/styles/styles.css"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js" type="module"/>
     <style nonce="ckE0bmQwbW1tckE0bmQwbW1t" id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/fixtures/content/nonce-script-only.html
+++ b/test/fixtures/content/nonce-script-only.html
@@ -18,6 +18,7 @@
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>
     <link rel="stylesheet" href="/styles/styles.css" />
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t"> const a = 1 </script>
+    <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
     <style id="at-body-style">body {opacity: 1}</style>
 </head>
 <body>

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -597,6 +597,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -621,6 +622,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -646,6 +648,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -664,6 +667,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem"> const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -690,6 +694,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="aem" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem" > const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="aem" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -714,6 +719,7 @@ describe('Rendering', () => {
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="aem"> const a = 1 </script>\n'
+            + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>\n'
             + '<style id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -732,6 +738,7 @@ describe('Rendering', () => {
             + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
         },
       };
@@ -756,6 +763,7 @@ describe('Rendering', () => {
             + '<script nonce="r4nD0m" src="/scripts/scripts.js" type="module"></script>\n'
             + '<link nonce="r4nD0m" rel="stylesheet" href="/styles/styles.css"/>\n'
             + '<script nonce="r4nD0m" > const a = 1 </script>\n'
+            + '<link nonce="r4nD0m" rel="preload" as="script" href="/scripts/aem.js" type="module"/>\n'
             + '<style nonce="r4nD0m" id="at-body-style">body {opacity: 1}</style>',
         },
       };


### PR DESCRIPTION
While testing the feature for https://www.jcperreault.com/ , I noticed that they have a case which is not covered by the current code.

The browser will block the download of the following script, without the correct nonce value.

```html
<link rel="preload" href="/scripts/lib/swiper/swiper-bundle.min.js" as="script">
```
