### PR TITLE
feat: read metadata directly from source if required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-html-pipeline",
-  "version": "6.21.6",
+  "version": "6.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-html-pipeline",
-      "version": "6.21.6",
+      "version": "6.24.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "7.1.12",

--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -36,6 +36,7 @@ import { PipelineResponse } from './PipelineResponse.js';
 import { validatePathInfo } from './utils/path.js';
 import fetchMappedMetadata from './steps/fetch-mapped-metadata.js';
 import { applyMetaLastModified, setLastModified } from './utils/last-modified.js';
+import fetchSourcedMetadata from './steps/fetch-sourced-metadata.js';
 
 /**
  * Fetches the content and if not found, fetches the 404.html
@@ -132,6 +133,7 @@ export async function htmlPipe(state, req) {
     state.timer?.update('metadata-fetch');
     await Promise.all([
       contentPromise,
+      fetchSourcedMetadata(state, res),
       fetchMappedMetadata(state, res),
     ]);
 

--- a/src/steps/fetch-sourced-metadata.js
+++ b/src/steps/fetch-sourced-metadata.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { PipelineStatusError } from '../PipelineStatusError.js';
+import { Modifiers } from '../utils/modifiers.js';
+
+/**
+ * Loads metadata from the metadata sources if required. this happens when the amount of metadata
+ * was too large to include in the config response. the metadata is loaded if
+ * `state.metadata` is empty and `config.metadata.source` is not.
+ *
+ * @type PipelineStep
+ * @param {PipelineState} state
+ * @param {PipelineResponse} res
+ * @returns {Promise<void>}
+ */
+// eslint-disable-next-line no-unused-vars
+export default async function fetchSourcedMetadata(state, res) {
+  if (!state.metadata.isEmpty()) {
+    return;
+  }
+  const sources = state.config.metadata?.source || [];
+  if (sources.length === 0) {
+    return;
+  }
+
+  const { contentBusId, partition } = state;
+  const metadata = [];
+  await Promise.all(sources.map(async (src) => {
+    const key = `${contentBusId}/${partition}/${src}`;
+
+  }));
+  const metadataPath = `${mappedPath}/metadata.json`;
+  const ret = await state.s3Loader.getObject('helix-content-bus', key);
+  if (ret.status === 200) {
+    let json;
+    try {
+      json = JSON.parse(ret.body);
+    } catch (e) {
+      throw new PipelineStatusError(500, `failed parsing of ${metadataPath}: ${e.message}`);
+    }
+    const { data } = json.default ?? json;
+    if (!data) {
+      state.log.info(`default sheet missing in ${metadataPath}`);
+      return;
+    }
+
+    if (!Array.isArray(data)) {
+      throw new PipelineStatusError(500, `failed loading of ${metadataPath}: data must be an array`);
+    }
+
+    state.mappedMetadata = Modifiers.fromModifierSheet(
+      data,
+    );
+    // note, that the folder mapped metadata does not influence the last-modified calculation.
+    return;
+  }
+  if (ret.status !== 404) {
+    throw new PipelineStatusError(502, `failed to load ${metadataPath}: ${ret.status}`);
+  }
+}

--- a/src/utils/modifiers.js
+++ b/src/utils/modifiers.js
@@ -124,6 +124,14 @@ export class Modifiers {
     return new Modifiers(res);
   }
 
+  /**
+   * Returns true if there are no modifiers.
+   * @returns {boolean}
+   */
+  isEmpty() {
+    return this.modifiers.length === 0;
+  }
+
   constructor(config) {
     this.modifiers = Object.entries(config).map(([url, mods]) => {
       const pat = url.indexOf('*') >= 0 ? globToRegExp(url) : url;

--- a/test/modifiers.test.js
+++ b/test/modifiers.test.js
@@ -145,4 +145,13 @@ describe('Metadata', () => {
     const actual = Modifiers.fromModifierSheet(data).getModifiers('/nope');
     assert.deepEqual(actual, {});
   });
+
+  it('isEmpty returns true, if empty', async () => {
+    assert.strictEqual(new Modifiers({}).isEmpty(), true);
+  });
+
+  it('isEmpty returns false, if not empty', async () => {
+    const { default: { data } } = await readTestJSON('metadata.json');
+    assert.strictEqual(Modifiers.fromModifierSheet(data).isEmpty(), false);
+  });
 });


### PR DESCRIPTION
if the metadata section of the config is too large, the config service will not longer include it, but specify the metadata sources. in this case, they are loaded in the html pipeline directly.

see https://github.com/adobe/helix-config/pull/259