### PR TITLE
fix: Rename "move-as-header" to "move-to-http-header"

### DIFF
--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -221,8 +221,9 @@ export function contentSecurityPolicyOnCode(state, res) {
             ({ scriptNonce, styleNonce } = shouldApplyNonce(contentAttr.value, cspHeader));
 
             if (!cspHeader
-              && tag.attrs.find((attr) => (attr.name === 'move-as-header' || attr.name === 'move-to-http-header')
-              && attr.value === 'true')
+              && tag.attrs.find(
+                (attr) => (attr.name === 'move-as-header' || attr.name === 'move-to-http-header') && attr.value === 'true',
+              )
             ) {
               res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
               return; // don't push the chunk so it gets removed from the response body

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -166,17 +166,17 @@ export function contentSecurityPolicyOnAST(res, tree) {
     || headersCSPRO?.includes(NONCE_AEM)
   ) {
     createAndApplyNonceOnAST(res, tree, metaCSP, headersCSP, headersCSPRO);
-  }
 
-  if (metaCSP?.properties['move-as-header'] === 'true' || metaCSP?.properties['move-to-http-header'] === 'true') {
-    if (!headersCSP) {
-      // if we have a CSP in meta but no CSP in headers
-      // we can move the CSP from meta to headers, if requested
-      res.headers.set('content-security-policy', metaCSP.properties.content);
-      remove(tree, null, metaCSP);
-    } else {
-      delete metaCSP.properties['move-as-header'];
-      delete metaCSP.properties['move-to-http-header'];
+    if (metaCSP?.properties['move-as-header'] === 'true' || metaCSP?.properties['move-to-http-header'] === 'true') {
+      if (!headersCSP) {
+        // if we have a CSP in meta but no CSP in headers
+        // we can move the CSP from meta to headers, if requested
+        res.headers.set('content-security-policy', metaCSP.properties.content);
+        remove(tree, null, metaCSP);
+      } else {
+        delete metaCSP.properties['move-as-header'];
+        delete metaCSP.properties['move-to-http-header'];
+      }
     }
   }
 }

--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -168,7 +168,7 @@ export function contentSecurityPolicyOnAST(res, tree) {
     createAndApplyNonceOnAST(res, tree, metaCSP, headersCSP, headersCSPRO);
   }
 
-  if (metaCSP?.properties['move-as-header'] === 'true') {
+  if (metaCSP?.properties['move-as-header'] === 'true' || metaCSP?.properties['move-to-http-header'] === 'true') {
     if (!headersCSP) {
       // if we have a CSP in meta but no CSP in headers
       // we can move the CSP from meta to headers, if requested
@@ -176,6 +176,7 @@ export function contentSecurityPolicyOnAST(res, tree) {
       remove(tree, null, metaCSP);
     } else {
       delete metaCSP.properties['move-as-header'];
+      delete metaCSP.properties['move-to-http-header'];
     }
   }
 }
@@ -219,7 +220,10 @@ export function contentSecurityPolicyOnCode(state, res) {
           if (contentAttr) {
             ({ scriptNonce, styleNonce } = shouldApplyNonce(contentAttr.value, cspHeader));
 
-            if (!cspHeader && tag.attrs.find((attr) => attr.name === 'move-as-header' && attr.value === 'true')) {
+            if (!cspHeader
+              && tag.attrs.find((attr) => (attr.name === 'move-as-header' || attr.name === 'move-to-http-header')
+              && attr.value === 'true')
+            ) {
               res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
               return; // don't push the chunk so it gets removed from the response body
             }

--- a/test/fixtures/code/super-test/404-csp-nonce.html
+++ b/test/fixtures/code/super-test/404-csp-nonce.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';" move-as-header="true">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';" move-to-http-header="true">
   <title>Page not found</title>
   <script nonce="aem" type="text/javascript">
     window.isErrorPage = true;

--- a/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
+++ b/test/fixtures/code/super-test/static-nonce-meta-move-as-header.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">
+    <meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-to-http-header="true">
     <title>ACME CORP</title>
     <link rel="canonical" href="https://www.adobe.com/nonce-headers-meta">
     <meta name="description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu tempor congue, nisi erat condimentum nunc, eget tincidunt nisl nunc euismod.">

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -722,7 +722,7 @@ describe('Rendering', () => {
         ...DEFAULT_CONFIG,
         head: {
           // eslint-disable-next-line quotes
-          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true" />\n`
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-to-http-header="true" />\n`
             + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>\n'
             + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'
@@ -749,7 +749,7 @@ describe('Rendering', () => {
         },
         head: {
           // eslint-disable-next-line quotes
-          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-as-header="true">\n`
+          html: `<meta http-equiv="content-security-policy" content="script-src 'nonce-aem' 'strict-dynamic'; style-src 'nonce-aem'; base-uri 'self'; object-src 'none';" move-to-http-header="true">\n`
             + '<link nonce="aem" rel="preload" as="script" href="/scripts/aem.js"/>\n'
             + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>\n'
             + '<script nonce="aem" src="/scripts/scripts.js" type="module"></script>\n'


### PR DESCRIPTION
This PR contains two changes:
- Renaming `"move-as-header"` to `"move-to-http-header"` as requested by David, to make it more clear what it does
- We have to keep the old name until I migrate the early adopters, so after migrating them, I'll come back to cleanup
- Allow `"move-to-http-header"` only for `nonce-aem` based CSP, because that's the only way we support it for the static HTMLs.