### PR TITLE
fix: add loading lazy for external images (#919)

### DIFF
--- a/src/html-pipe.js
+++ b/src/html-pipe.js
@@ -21,6 +21,7 @@ import fixSections from './steps/fix-sections.js';
 import { calculateFolderMapping, applyFolderMapping } from './steps/folder-mapping.js';
 import getMetadata from './steps/get-metadata.js';
 import html from './steps/make-html.js';
+import lazyLoadExternalImages from './steps/lazy-load-external-images.js';
 import parseMarkdown from './steps/parse-markdown.js';
 import render from './steps/render.js';
 import renderCode from './steps/render-code.js';
@@ -166,6 +167,7 @@ export async function htmlPipe(state, req) {
       await fixSections(state);
       await createPageBlocks(state);
       await createPictures(state);
+      await lazyLoadExternalImages(state);
       await extractMetaData(state, req);
       await addHeadingIds(state);
       await setCustomResponseHeaders(state, req, res);

--- a/src/steps/lazy-load-external-images.js
+++ b/src/steps/lazy-load-external-images.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { visit } from 'unist-util-visit';
+
+function isExternalImage(node) {
+  return node.tagName === 'img' && node.properties?.src && !node.properties?.src.startsWith('./media_');
+}
+
+/**
+ * Adds loading="lazy" to external images
+ * @type PipelineStep
+ * @param context The current context of processing pipeline
+ */
+export default async function lazyLoadExternalImages({ content }) {
+  const { hast } = content;
+
+  visit(hast, isExternalImage, (img) => {
+    const { loading } = img.properties;
+    if (!loading) {
+      img.properties.loading = 'lazy';
+    }
+  });
+}

--- a/test/fixtures/content/images.html
+++ b/test/fixtures/content/images.html
@@ -63,5 +63,9 @@
                 <img loading="lazy" alt=""  src="./media_ba025e72d401d61d991debe0a2128048fabe0a4f.png?width=750&#x26;format=png&#x26;optimize=medium">
             </picture>
         </p>
+        <p>external image</p>
+        <p>
+            <img loading="lazy" alt=""  src="https://delivery-p12345-e67890.adobeaemcloud.com/adobe/assets/urn:aaid:aem:11112222-1111-2222-1111-222211112222/as/name.avif?assetname=name.jpg">
+        </p>
     </div>
 </main>

--- a/test/fixtures/content/images.md
+++ b/test/fixtures/content/images.md
@@ -26,3 +26,6 @@ image wrapped in strong
 
 **![](https://main--pages--adobe.hlx.live/media_ba025e72d401d61d991debe0a2128048fabe0a4f.png)**
 
+external image
+
+![](https://delivery-p12345-e67890.adobeaemcloud.com/adobe/assets/urn:aaid:aem:11112222-1111-2222-1111-222211112222/as/name.avif?assetname=name.jpg)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://github.com/adobe/helix-html-pipeline/issues/919

Thanks for contributing!
