### PR TITLE
fix: catch invalid regex from globToRegExp

### DIFF
--- a/src/utils/modifiers.js
+++ b/src/utils/modifiers.js
@@ -28,7 +28,12 @@ export function globToRegExp(glob) {
     .replaceAll('**', '|')
     .replaceAll('*', '[0-9a-z-.]*')
     .replaceAll('|', '.*');
-  return new RegExp(`^${reString}$`);
+  try {
+    return new RegExp(`^${reString}$`);
+  } catch {
+    // glob compiled to an invalid regex
+    return null;
+  }
 }
 
 /**

--- a/test/modifiers.test.js
+++ b/test/modifiers.test.js
@@ -16,7 +16,7 @@
 import assert from 'assert';
 import path from 'path';
 import { readFile } from 'fs/promises';
-import { Modifiers } from '../src/utils/modifiers.js';
+import { Modifiers, globToRegExp } from '../src/utils/modifiers.js';
 
 async function readTestJSON(filename) {
   return JSON.parse(await readFile(path.resolve(__testdir, 'fixtures', 'content', filename), 'utf-8'));
@@ -148,6 +148,26 @@ describe('Metadata', () => {
 
   it('isEmpty returns true, if empty', async () => {
     assert.strictEqual(new Modifiers({}).isEmpty(), true);
+  });
+
+  it('globToRegExp returns null when the glob compiles to an invalid regex', () => {
+    // the `*` is replaced with `[0-9a-z-.]*`, leaving an unbalanced `(`
+    assert.strictEqual(globToRegExp('/bad/(*'), null);
+  });
+
+  it('globToRegExp returns a RegExp for a valid glob', () => {
+    const re = globToRegExp('/foo/*');
+    assert.ok(re instanceof RegExp);
+    assert.strictEqual(re.test('/foo/bar'), true);
+  });
+
+  it('skips entries with globs that compile to an invalid regex', async () => {
+    const mods = new Modifiers({
+      '/good/*': [{ key: 'title', value: 'Good' }],
+      '/bad/(*': [{ key: 'title', value: 'Bad' }],
+    });
+    assert.deepEqual(mods.getModifiers('/good/page'), { title: 'Good' });
+    assert.deepEqual(mods.getModifiers('/bad/(page'), {});
   });
 
   it('isEmpty returns false, if not empty', async () => {


### PR DESCRIPTION
Fix #1092