### PR TITLE
fix: support media_ files on deeper paths

### DIFF
--- a/src/steps/utils.js
+++ b/src/steps/utils.js
@@ -12,7 +12,7 @@
 
 const AZURE_BLOB_REGEXP = /^https:\/\/hlx\.blob\.core\.windows\.net\/external\//;
 
-const MEDIA_BLOB_REGEXP = /^https:\/\/.*\.(aem|hlx3?)\.(live|page)\/media_.*/;
+const MEDIA_BLOB_REGEXP = /^https:\/\/.*\.(aem|hlx3?)\.(live|page)(\/.*)?\/media_.*/;
 
 const HELIX_URL_REGEXP = /^https:\/\/.*\.(aem|hlx3?)\.(live|page)\/?.*/;
 
@@ -236,7 +236,8 @@ export function rewriteUrl(state, url) {
     }
 
     if (MEDIA_BLOB_REGEXP.test(url)) {
-      return `.${pathname}${hash}`;
+      const filename = pathname.split('/').pop();
+      return `./${filename}${hash}`;
     }
 
     if ((host.includes('--') && HELIX_URL_REGEXP.test(url))

--- a/test/steps/utils.test.js
+++ b/test/steps/utils.test.js
@@ -133,6 +133,8 @@ describe('Rewrite URLs test', () => {
     assert.strictEqual(rewriteUrl({}, 'https://main--pages--adobe.hlx3.page/media_1234.png'), './media_1234.png');
     assert.strictEqual(rewriteUrl({}, 'https://main--pages--adobe.aem.page/media_1234.png'), './media_1234.png');
     assert.strictEqual(rewriteUrl({}, 'https://main--pages--adobe.aem.live/media_1234.png'), './media_1234.png');
+    assert.strictEqual(rewriteUrl({}, 'https://main--pages--adobe.aem.live/some/path/media_1234.png'), './media_1234.png');
+    assert.strictEqual(rewriteUrl({}, 'https://main--pages--adobe.hlx.live/some/path/media_1234.png#width=800&height=600'), './media_1234.png#width=800&height=600');
   });
 
   it('replaces an helix url', () => {


### PR DESCRIPTION
## Summary

- Update `MEDIA_BLOB_REGEXP` to match `/media_` at any path depth (e.g. `/some/path/media_abc.png`)
- Extract just the filename in `rewriteUrl` so the rewritten URL is always `./media_<name>` regardless of the original path depth

## Test plan

- [x] Added test cases for `media_` URLs with sub-paths to the existing `replaces an helix media url` test
- [x] All existing tests continue to pass (`npx mocha test/steps/utils.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)