### PR TITLE
#1078 Remove overridden CSP meta tags

### DIFF
--- a/src/steps/csp.js
+++ b/src/steps/csp.js
@@ -172,11 +172,8 @@ export function contentSecurityPolicyOnAST(res, tree) {
         // if we have a CSP in meta but no CSP in headers
         // we can move the CSP from meta to headers, if requested
         res.headers.set('content-security-policy', metaCSP.properties.content);
-        remove(tree, null, metaCSP);
-      } else {
-        delete metaCSP.properties['move-as-header'];
-        delete metaCSP.properties['move-to-http-header'];
       }
+      remove(tree, null, metaCSP);
     }
   }
 }
@@ -220,12 +217,13 @@ export function contentSecurityPolicyOnCode(state, res) {
           if (contentAttr) {
             ({ scriptNonce, styleNonce } = shouldApplyNonce(contentAttr.value, cspHeader));
 
-            if (!cspHeader
-              && tag.attrs.find(
-                (attr) => (attr.name === 'move-as-header' || attr.name === 'move-to-http-header') && attr.value === 'true',
-              )
-            ) {
-              res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
+            const moveToHeader = tag.attrs.find(
+              (attr) => (attr.name === 'move-as-header' || attr.name === 'move-to-http-header') && attr.value === 'true',
+            );
+            if (moveToHeader) {
+              if (!cspHeader) {
+                res.headers.set('content-security-policy', contentAttr.value.replaceAll(NONCE_AEM, `'nonce-${nonce}'`));
+              }
               return; // don't push the chunk so it gets removed from the response body
             }
             chunks.push(getRawHTML(tag).replaceAll(NONCE_AEM, `'nonce-${nonce}'`));

--- a/test/fixtures/content/nonce-headers-meta.html
+++ b/test/fixtures/content/nonce-headers-meta.html
@@ -14,7 +14,6 @@
     <meta name="twitter:image" content="https://www.adobe.com/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="locale" content="en-US">
     <meta name="zero-cell" content="0">
-    <meta http-equiv="content-security-policy" content="script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';">
     <link nonce="ckE0bmQwbW1tckE0bmQwbW1t" rel="preload" as="script" href="/scripts/aem.js"/>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/aem.js" type="module"></script>
     <script nonce="ckE0bmQwbW1tckE0bmQwbW1t" src="/scripts/scripts.js" type="module"></script>

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -794,7 +794,7 @@ describe('Rendering', () => {
       assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
     });
 
-    it('renders csp nonce headers and metadata - move as header', async () => {
+    it('removes csp nonce metadata moved as header when header exists', async () => {
       config = {
         ...DEFAULT_CONFIG,
         headers: {
@@ -1233,6 +1233,23 @@ describe('Rendering', () => {
       const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
       // eslint-disable-next-line quotes
       assert.strictEqual(headers.get('content-security-policy'), `script-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t' 'strict-dynamic'; style-src 'nonce-ckE0bmQwbW1tckE0bmQwbW1t'; base-uri 'self'; object-src 'none';`);
+    });
+
+    it('removes static csp metadata moved as header when header exists', async () => {
+      config = {
+        ...DEFAULT_CONFIG,
+        headers: {
+          '/**': [
+            {
+              key: 'content-security-policy',
+              value: 'frame-ancestors \'self\'',
+            },
+          ],
+        },
+      };
+
+      const { headers } = await testRenderCode(new URL('https://helix-pages.com/static-nonce-meta-move-as-header.html'));
+      assert.strictEqual(headers.get('content-security-policy'), 'frame-ancestors \'self\'');
     });
 
     it('renders static html from the codebus and applies csp with different nonce without altering', async () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

Fixes #1078

## What changed

- Remove a CSP meta tag marked `move-as-header` or `move-to-http-header` when a configured `Content-Security-Policy` response header already exists.
- Apply the same behavior to both the AST renderer and the raw HTML tokenizer path.
- Preserve the existing behavior that promotes the meta policy into a response header when no enforcing CSP header exists.

This makes the configured response header authoritative instead of leaving two CSP policies in the response. It does not change unmarked meta policies, report-only headers, or nonce generation and application.

## Verification

- Added deterministic regressions for both rendering paths; each failed before the production change.
- `npm test` — 336 passing, with 100% statement, branch, and line coverage.
- `npm run lint`
- Two independent reviews found no blocking issues.

Thanks for contributing!
