### PR TITLE
fix: resolve custom og:image/twitter:image metadata to absolute urls

### DIFF
--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -285,6 +285,22 @@ export default function extractMetaData(state, req) {
 
   meta.imageAlt = meta['image-alt'] ?? content.imageAlt;
 
+  // custom og:image/twitter:image overrides authored directly in the metadata block or sheet
+  // should be resolved to an absolute, optimized url, just like the default image, but only
+  // if they actually look like a url or path. plain text values are passed through as-is.
+  ['og:image', 'og:image:secure_url', 'twitter:image'].forEach((name) => {
+    const value = metaConfig[name];
+    if (value && /^(https?:\/\/|\.?\/)/.test(value)) {
+      try {
+        let img = rewriteUrl(state, value);
+        img = optimizeMetaImage(state.info.path, img);
+        metaConfig[name] = getAbsoluteUrl(state, img);
+      } catch (e) {
+        // ignore url errors
+      }
+    }
+  });
+
   // compute the final page metadata
   const metadata = {
     description: meta.description,

--- a/test/fixtures/content/page-metadata-block-custom-og-image-invalid.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-invalid.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image-invalid">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image-invalid">
+    <meta property="og:image" content="https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-og-image-invalid.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-invalid.html
@@ -5,12 +5,12 @@
     <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image-invalid">
     <meta property="og:title" content="Hero">
     <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image-invalid">
-    <meta property="og:image" content="https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png">
+    <meta property="og:image" content="https://main--pages-- .aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png">
     <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta property="og:image:alt" content="Hero image">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Hero">
-    <meta name="twitter:image" content="https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png">
+    <meta name="twitter:image" content="https://main--pages-- .aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png">
     <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/scripts.js" type="module"></script>

--- a/test/fixtures/content/page-metadata-block-custom-og-image-invalid.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-invalid.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|og:image|https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image-invalid.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-invalid.md
@@ -1,8 +1,8 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||
 |-|-|
-|og:image|https://hlx--- .blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|
+|og:image|https://main--pages-- .aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image-path.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-path.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image-path">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image-path">
+    <meta property="og:image" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-og-image-path.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-path.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|og:image|/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image-path.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-path.md
@@ -1,6 +1,6 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||

--- a/test/fixtures/content/page-metadata-block-custom-og-image-plain.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-plain.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image-plain">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image-plain">
+    <meta property="og:image" content="A custom social preview">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="A custom social preview">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-og-image-plain.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-plain.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|og:image|A custom social preview|

--- a/test/fixtures/content/page-metadata-block-custom-og-image-plain.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-plain.md
@@ -1,6 +1,6 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||

--- a/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image-secure-url">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image-secure-url">
+    <meta property="og:image" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|og:image:secure_url|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image-secure-url.md
@@ -1,8 +1,8 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||
 |-|-|
-|og:image:secure_url|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|
+|og:image:secure_url|https://main--pages--adobe.aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image.html
+++ b/test/fixtures/content/page-metadata-block-custom-og-image.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-og-image">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-og-image">
+    <meta property="og:image" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-og-image.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|og:image|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|

--- a/test/fixtures/content/page-metadata-block-custom-og-image.md
+++ b/test/fixtures/content/page-metadata-block-custom-og-image.md
@@ -1,8 +1,8 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||
 |-|-|
-|og:image|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|
+|og:image|https://main--pages--adobe.aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png|

--- a/test/fixtures/content/page-metadata-block-custom-twitter-image.html
+++ b/test/fixtures/content/page-metadata-block-custom-twitter-image.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hero</title>
+    <link rel="canonical" href="https://helix-pages.com/page-metadata-block-custom-twitter-image">
+    <meta property="og:title" content="Hero">
+    <meta property="og:url" content="https://helix-pages.com/page-metadata-block-custom-twitter-image">
+    <meta property="og:image" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:alt" content="Hero image">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hero">
+    <meta name="twitter:image" content="https://helix-pages.com/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header></header>
+<main>
+    <div>
+        <h1 id="hero">Hero</h1>
+        <p>
+            <picture>
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                <source type="image/webp" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                <source type="image/png" srcset="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                <img loading="lazy" alt="Hero image"  src="./media_a22b1a53edf9b324465d14b2efca169a25d564a0.png?width=750&#x26;format=png&#x26;optimize=medium">
+            </picture>
+        </p>
+    </div>
+</main>
+<footer></footer>
+</body>
+</html>

--- a/test/fixtures/content/page-metadata-block-custom-twitter-image.md
+++ b/test/fixtures/content/page-metadata-block-custom-twitter-image.md
@@ -1,0 +1,8 @@
+# Hero
+
+![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+
+
+|Metadata||
+|-|-|
+|twitter:image|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|

--- a/test/fixtures/content/page-metadata-block-custom-twitter-image.md
+++ b/test/fixtures/content/page-metadata-block-custom-twitter-image.md
@@ -1,8 +1,8 @@
 # Hero
 
-![Hero image](https://hlx.blob.core.windows.net/external/a22b1a53edf9b324465d14b2efca169a25d564a0#image.png)
+![Hero image](https://main--pages--adobe.aem.live/media_a22b1a53edf9b324465d14b2efca169a25d564a0.png)
 
 
 |Metadata||
 |-|-|
-|twitter:image|https://hlx.blob.core.windows.net/external/67af739484f3d60dc64e306ccbf9b90a6d63a24c#image.png|
+|twitter:image|https://main--pages--adobe.aem.live/media_67af739484f3d60dc64e306ccbf9b90a6d63a24c.png|

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -454,6 +454,11 @@ describe('Rendering', () => {
       await testRender('page-metadata-block-custom-og-image', 'html');
     });
 
+    it('leaves invalid custom og:image untouched', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-og-image-invalid', 'html');
+    });
+
     it('uses correct description', async () => {
       config = DEFAULT_CONFIG_EMPTY;
       await testRender('description-long', 'head');

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -459,6 +459,26 @@ describe('Rendering', () => {
       await testRender('page-metadata-block-custom-og-image-invalid', 'html');
     });
 
+    it('resolves custom og:image given as an absolute path', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-og-image-path', 'html');
+    });
+
+    it('passes plain-text custom og:image through untouched', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-og-image-plain', 'html');
+    });
+
+    it('resolves custom og:image:secure_url independently', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-og-image-secure-url', 'html');
+    });
+
+    it('resolves custom twitter:image independently', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-twitter-image', 'html');
+    });
+
     it('uses correct description', async () => {
       config = DEFAULT_CONFIG_EMPTY;
       await testRender('description-long', 'head');

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -449,6 +449,11 @@ describe('Rendering', () => {
       await testRender('image-from-meta-rewrite-link', 'html');
     });
 
+    it('uses absolute og:image when set as custom metadata (issue #768)', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('page-metadata-block-custom-og-image', 'html');
+    });
+
     it('uses correct description', async () => {
       config = DEFAULT_CONFIG_EMPTY;
       await testRender('description-long', 'head');


### PR DESCRIPTION
## Summary
- Custom `og:image`, `og:image:secure_url`, and `twitter:image` values authored in a page's metadata block (or metadata sheet) were rendered into `<meta>` tags as-is, skipping the url rewriting/optimization/absolutization that the default `image` metadata property gets. A relative path like `./media_....png` would end up relative in the final markup instead of absolute.
- Values that look like a url or path (`http(s)://`, `/`, or `./`) are now resolved through the same `rewriteUrl` → `optimizeMetaImage` → `getAbsoluteUrl` pipeline used for the default image. Plain-text values (e.g. placeholder text unrelated to an actual image) are left untouched, preserving existing behavior covered by the `page-metadata-twitter-fallback` test.
- Added a regression test (`page-metadata-block-custom-og-image.md`/`.html`) reproducing the scenario from the linked issue: a hero image plus a distinct custom `og:image` set via the metadata block, verifying it renders as an absolute, optimized url.

## Test plan
- [x] `npx mocha "test/**/*.test.js"` — all 335 tests pass
- [x] `npx eslint src/steps/extract-metadata.js test/rendering.test.js` — clean
- [x] New test: `uses absolute og:image when set as custom metadata (issue #768)`
- [x] Verified existing `sets proper twitter fallbacks` test (plain-text custom values) still passes unchanged

## Related Issues
Fixes #768