### PR TITLE
fix: reject non-object json root (incl. null) in json-filter

### DIFF
--- a/src/utils/json-filter.js
+++ b/src/utils/json-filter.js
@@ -64,6 +64,10 @@ export default function jsonFilter(state, res, query) {
     return;
   }
 
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new PipelineStatusError(sourceBus === 'code' ? 400 : 502, 'json sheet is not an object.');
+  }
+
   // when raw request, only handle multisheets.
   if (raw && !(NAMES_KEY in json)) {
     res.body = data;

--- a/test/utils/json-filter.test.js
+++ b/test/utils/json-filter.test.js
@@ -328,6 +328,65 @@ describe('JSON Filter test', () => {
     ), new PipelineStatusError(404, 'filtered result does not contain selected sheet(s): foo'));
   });
 
+  describe('non-object json root', () => {
+    const CODE_STATE = (data) => ({
+      log: console,
+      content: {
+        data,
+        sourceBus: 'code',
+      },
+    });
+
+    const NON_OBJECT_ROOTS = {
+      string: '2.0.0-beta.2',
+      number: 42,
+      boolean: true,
+      null: null,
+      array: [1, 2, 3],
+    };
+
+    Object.entries(NON_OBJECT_ROOTS).forEach(([name, value]) => {
+      it(`rejects json ${name} root with 502 for content bus`, async () => {
+        const resp = new PipelineResponse('', {
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+        assert.throws(() => jsonFilter(
+          DEFAULT_STATE(JSON.stringify(value)),
+          resp,
+          {},
+        ), new PipelineStatusError(502, 'json sheet is not an object.'));
+      });
+
+      it(`rejects json ${name} root with 400 for code bus`, async () => {
+        const resp = new PipelineResponse('', {
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+        assert.throws(() => jsonFilter(
+          CODE_STATE(JSON.stringify(value)),
+          resp,
+          {},
+        ), new PipelineStatusError(400, 'json sheet is not an object.'));
+      });
+    });
+
+    it('rejects json string root in raw mode instead of crashing', async () => {
+      const resp = new PipelineResponse('', {
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      assert.throws(() => jsonFilter(
+        DEFAULT_STATE(JSON.stringify('2.0.0-beta.2')),
+        resp,
+        { raw: true },
+      ), new PipelineStatusError(502, 'json sheet is not an object.'));
+    });
+  });
+
   it('truncates result if too large for action response', async () => {
     const resp = new PipelineResponse('', {
       headers: {


### PR DESCRIPTION
## Summary
- `jsonFilter` now validates that a parsed JSON document's root value is an object (and not `null` or an array) before treating it as a sheet/multisheet, throwing a `PipelineStatusError` (502 for content bus, 400 for code bus) instead of leaking an unhandled `TypeError`.
- Fixes the crash from `NAMES_KEY in json` when `json` is a primitive, `null`, or array — e.g. a content bus JSON document that is just the string `"2.0.0-beta.2"`.
- Adds tests in `test/utils/json-filter.test.js` covering string, number, boolean, `null`, and array root values, for both content-bus and code-bus source, plus the `raw: true` request path.

Fixes #1121

## Test plan
- [x] `npm test` — full suite passes (346 passing), 100% statement/branch/line coverage maintained
- [x] `npm run lint` — clean
- [x] New tests reproduce the original crash (verified pre-fix that `null` still threw a raw `TypeError`) and confirm it's now a clean `PipelineStatusError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)