### PR TITLE
fix: return raw body for non-object json root in raw mode for code bus

### DIFF
--- a/src/utils/json-filter.js
+++ b/src/utils/json-filter.js
@@ -65,6 +65,10 @@ export default function jsonFilter(state, res, query) {
   }
 
   if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    if (raw && sourceBus === 'code') {
+      res.body = data;
+      return;
+    }
     throw new PipelineStatusError(sourceBus === 'code' ? 400 : 502, 'json sheet is not an object.');
   }
 

--- a/test/utils/json-filter.test.js
+++ b/test/utils/json-filter.test.js
@@ -373,6 +373,23 @@ describe('JSON Filter test', () => {
       });
     });
 
+    Object.entries(NON_OBJECT_ROOTS).forEach(([name, value]) => {
+      it(`returns raw body for json ${name} root in raw mode for code bus`, async () => {
+        const resp = new PipelineResponse('', {
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+        jsonFilter(
+          CODE_STATE(JSON.stringify(value)),
+          resp,
+          { raw: true },
+        );
+        assert.strictEqual(resp.status, 200);
+        assert.strictEqual(resp.body, JSON.stringify(value));
+      });
+    });
+
     it('rejects json string root in raw mode instead of crashing', async () => {
       const resp = new PipelineResponse('', {
         headers: {


### PR DESCRIPTION
## Summary
- In `jsonFilter`, when a raw request targets a code-bus JSON file whose parsed root is not an object (string, number, boolean, null, or array), return the raw body directly instead of throwing a 400 error — mirroring the existing broken-json raw passthrough behavior.
- Added test coverage for this new branch in `test/utils/json-filter.test.js`, covering all non-object root types (string, number, boolean, null, array) via the existing `CODE_STATE`/`NON_OBJECT_ROOTS` fixtures.

## Test plan
- [x] `npm test` — full suite passes (351 passing, 100% statement/branch coverage)
- [x] `npm run lint` — clean
- [x] New tests verify `resp.status === 200` and `resp.body` equals the raw JSON string for each non-object root type under `{ raw: true }` + code bus

🤖 Generated with [Claude Code](https://claude.com/claude-code)