### PR TITLE
fix: #1134 strip icon notation from auto-generated description

### DIFF
--- a/src/steps/extract-metadata.js
+++ b/src/steps/extract-metadata.js
@@ -18,6 +18,7 @@ import {
 } from './utils.js';
 import { toMetaName } from '../utils/modifiers.js';
 import { childNodes } from '../utils/hast-utils.js';
+import { REGEXP_ICON } from './rewrite-icons.js';
 
 // common web image extensions
 const IMAGE_EXTENSIONS = new Set(['avif', 'webp', 'png', 'jpg', 'jpeg', 'gif']);
@@ -178,7 +179,13 @@ function extractDescription(hast) {
   let desc = '';
   visit(hast, (node, idx, parent) => {
     if (parent?.tagName === 'div' && node.tagName === 'p') {
-      const words = toString(node).trim().split(/\s+/);
+      // strip icon notation (e.g. ":icon-name:") so it doesn't leak into the description.
+      // this step runs before rewrite-icons, so icons are still authored as text here.
+      const words = toString(node)
+        .replace(REGEXP_ICON, '')
+        .trim()
+        .split(/\s+/)
+        .filter((w) => w);
       if (words.length >= 10 || words.some((w) => w.length > 25 && !w.startsWith('http'))) {
         desc = `${words.slice(0, 25).join(' ')}${words.length > 25 ? ' ...' : ''}`;
         return EXIT;

--- a/src/steps/rewrite-icons.js
+++ b/src/steps/rewrite-icons.js
@@ -13,7 +13,7 @@
 import { h } from 'hastscript';
 import { CONTINUE, SKIP, visit } from 'unist-util-visit';
 
-const REGEXP_ICON = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
+export const REGEXP_ICON = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
 
 /**
  * Create a <span> icon element:

--- a/test/fixtures/content/description-icon.html
+++ b/test/fixtures/content/description-icon.html
@@ -1,0 +1,17 @@
+<head><title>Hello</title>
+    <link rel="canonical" href="https://helix-pages.com/description-icon">
+    <meta name="description" content="This is the first long paragraph with more than ten words so it will be used.">
+    <meta property="og:title" content="Hello">
+    <meta property="og:description" content="This is the first long paragraph with more than ten words so it will be used.">
+    <meta property="og:url" content="https://helix-pages.com/description-icon">
+    <meta property="og:image" content="https://helix-pages.com/default-meta-image.png?width=1200&amp;format=pjpg&amp;optimize=medium">
+    <meta property="og:image:secure_url" content="https://helix-pages.com/default-meta-image.png?width=1200&amp;format=pjpg&amp;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hello">
+    <meta name="twitter:description" content="This is the first long paragraph with more than ten words so it will be used.">
+    <meta name="twitter:image" content="https://helix-pages.com/default-meta-image.png?width=1200&amp;format=pjpg&amp;optimize=medium">
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles.css">
+</head>

--- a/test/fixtures/content/description-icon.md
+++ b/test/fixtures/content/description-icon.md
@@ -1,0 +1,5 @@
+# Hello
+
+:home: This is the first long paragraph with more than ten words so it will be used.
+
+And this is the last.

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -504,6 +504,11 @@ describe('Rendering', () => {
       await testRender('description-blockquote', 'head');
     });
 
+    it('strips icon notation from auto-generated description', async () => {
+      config = DEFAULT_CONFIG_EMPTY;
+      await testRender('description-icon', 'head');
+    });
+
     it('does not fallback for empty cell', async () => {
       await testRender('page-metadata-no-fallback', 'head');
     });


### PR DESCRIPTION
When a page has no authored description, the pipeline auto-generates one from the first paragraph with 10+ words. Because extractMetaData runs before rewriteIcons, icon notation (e.g. ":icon-name:") is still raw text at extraction time and leaked into the description/og:description/ twitter:description meta tags.

extractDescription now strips icon notation before counting words and slicing, reusing the exported REGEXP_ICON from rewrite-icons.js so the two stay in sync. Reusing that regex also preserves colon-looking tokens inside URLs via its existing negative lookbehind.

Fixes #1134

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
