### PR TITLE
feat(metadata): support 'hreflang:' prefix

### DIFF
--- a/src/steps/render.js
+++ b/src/steps/render.js
@@ -82,7 +82,7 @@ export default async function render(state, req, res) {
       // eslint-disable-next-line no-continue
       continue;
     }
-    if (name.startsWith('hreflang-')) {
+    if (name.startsWith('hreflang:')) {
       const lang = name.substring(9);
       if (lang) {
         appendElement(

--- a/src/utils/modifiers.js
+++ b/src/utils/modifiers.js
@@ -16,9 +16,10 @@
  */
 export function toMetaName(text) {
   const name = text.replace(/[^0-9a-zA-Z:_-]/g, '-');
-  // preserve case for hreflang language tags (BCP 47)
-  if (name.toLowerCase().startsWith('hreflang-')) {
-    return `hreflang-${name.substring(9)}`;
+  // preserve case for hreflang language tags (BCP 47) and normalize the prefix
+  const lower = name.toLowerCase();
+  if (lower.startsWith('hreflang-') || lower.startsWith('hreflang:')) {
+    return `hreflang:${name.substring(9)}`;
   }
   return name.toLowerCase();
 }

--- a/test/fixtures/content/page-metadata-hreflang.html
+++ b/test/fixtures/content/page-metadata-hreflang.html
@@ -12,6 +12,7 @@
         <link rel="alternate" hreflang="de" href="https://helix-pages.com/de/page-metadata-hreflang">
         <link rel="alternate" hreflang="fr-FR" href="https://helix-pages.com/fr/page-metadata-hreflang">
         <link rel="alternate" hreflang="x-default" href="https://helix-pages.com/en/page-metadata-hreflang">
+        <link rel="alternate" hreflang="es" href="https://helix-pages.com/es/page-metadata-hreflang">
         <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="/scripts.js" type="module"></script>

--- a/test/fixtures/content/page-metadata-hreflang.html
+++ b/test/fixtures/content/page-metadata-hreflang.html
@@ -12,7 +12,6 @@
         <link rel="alternate" hreflang="de" href="https://helix-pages.com/de/page-metadata-hreflang">
         <link rel="alternate" hreflang="fr-FR" href="https://helix-pages.com/fr/page-metadata-hreflang">
         <link rel="alternate" hreflang="x-default" href="https://helix-pages.com/en/page-metadata-hreflang">
-        <link rel="alternate" hreflang="es" href="https://helix-pages.com/es/page-metadata-hreflang">
         <link id="favicon" rel="icon" type="image/svg+xml" href="/icons/spark.svg">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="/scripts.js" type="module"></script>

--- a/test/fixtures/content/page-metadata-hreflang.md
+++ b/test/fixtures/content/page-metadata-hreflang.md
@@ -7,9 +7,11 @@ This is great.
 +====================+==========================================================================+
 | title              | Home \| Helix Project Boilerplate                                        |
 +--------------------+--------------------------------------------------------------------------|
-| hreflang-de        | <https://helix-pages.com/de/page-metadata-hreflang>                      |
+| hreflang:de        | <https://helix-pages.com/de/page-metadata-hreflang>                      |
 +--------------------+--------------------------------------------------------------------------+
-| hreflang-fr-FR     | <https://helix-pages.com/fr/page-metadata-hreflang>                      |
+| hreflang:fr-FR     | <https://helix-pages.com/fr/page-metadata-hreflang>                      |
 +--------------------+--------------------------------------------------------------------------+
-| hreflang-x-default | <https://helix-pages.com/en/page-metadata-hreflang>                      |
+| hreflang:x-default | <https://helix-pages.com/en/page-metadata-hreflang>                      |
++--------------------+--------------------------------------------------------------------------+
+| hreflang-es        | <https://helix-pages.com/es/page-metadata-hreflang>                      |
 +--------------------+--------------------------------------------------------------------------+

--- a/test/fixtures/content/page-metadata-hreflang.md
+++ b/test/fixtures/content/page-metadata-hreflang.md
@@ -11,7 +11,5 @@ This is great.
 +--------------------+--------------------------------------------------------------------------+
 | hreflang:fr-FR     | <https://helix-pages.com/fr/page-metadata-hreflang>                      |
 +--------------------+--------------------------------------------------------------------------+
-| hreflang:x-default | <https://helix-pages.com/en/page-metadata-hreflang>                      |
-+--------------------+--------------------------------------------------------------------------+
-| hreflang-es        | <https://helix-pages.com/es/page-metadata-hreflang>                      |
+| hreflang-x-default | <https://helix-pages.com/en/page-metadata-hreflang>                      |
 +--------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
Adds support for a `hreflang:` prefix for page metadata, alongside the existing `hreflang-` prefix.

- `toMetaName` recognizes both prefixes (case-insensitively) and normalizes them to `hreflang:`, preserving the BCP 47 case of the language tag.
- `render.js` emits `<link rel="alternate" hreflang="...">` for the normalized names.
- Test fixtures updated to use `hreflang:`, with one legacy `hreflang-` entry retained for back-compat coverage.